### PR TITLE
Fix Windows game launch with UAC

### DIFF
--- a/ok/util/process.py
+++ b/ok/util/process.py
@@ -153,18 +153,35 @@ def execute(game_cmd: str, arguments=None):
                 try:
                     logger.info(f'try execute {game_cmd} {arguments}')
                     game_cmd_stripped = game_cmd.strip()
-                    if game_cmd_stripped.startswith('"'):
-                        cmd = f'start "" /b {game_cmd_stripped}'
+                    args_part = ''
+                    if game_cmd_stripped.startswith('"') and game_cmd_stripped.startswith(f'"{game_path}"'):
+                        args_part = game_cmd_stripped[len(game_path) + 2:].strip()
                     elif game_cmd_stripped.startswith(game_path):
-                        args_part = game_cmd_stripped[len(game_path):]
-                        cmd = f'start "" /b "{game_path}"{args_part}'
-                    else:
-                        cmd = f'start "" /b "{game_cmd_stripped}"'
-                    if arguments:
-                        cmd += f" {arguments}"
-                    subprocess.Popen(cmd, cwd=os.path.dirname(game_path), shell=True,
-                                     creationflags=0x00000008)  # detached process
-                    return True
+                        args_part = game_cmd_stripped[len(game_path):].strip()
+                    params = ' '.join(arg for arg in [args_part, arguments] if arg)
+                    result = ctypes.windll.shell32.ShellExecuteW(
+                        None,
+                        "open",
+                        game_path,
+                        params if params else None,
+                        os.path.dirname(game_path),
+                        1
+                    )
+                    if result > 32:
+                        return True
+                    logger.warning(f'ShellExecute open failed with code {result}, trying runas')
+                    result = ctypes.windll.shell32.ShellExecuteW(
+                        None,
+                        "runas",
+                        game_path,
+                        params if params else None,
+                        os.path.dirname(game_path),
+                        1
+                    )
+                    if result > 32:
+                        return True
+                    logger.error(f'ShellExecute failed with code {result}')
+                    return False
                 except Exception as e:
                     logger.error('execute error', e)
             else:


### PR DESCRIPTION
## Summary

企图修复解决了启动需要 UAC 权限的 Windows 游戏可执行文件的问题。

之前的实现方式是通过 `subprocess.Popen` 使用 `cmd start /b` 命令。对于需要权限的可执行文件，此操作可能会返回成功，但游戏窗口却始终不会出现，导致启动器一直等待直到超时。（问题源自okef，okww没有该问题）

## Test

修改后可以成功从okef绕过启动器直接启动endfield.exe，并且其余功能并未受影响
