### PR TITLE
fix: 游戏已运行时 -t 无界面启动应对设备就绪做轮询等待

### DIFF
--- a/ok/gui/StartController.py
+++ b/ok/gui/StartController.py
@@ -74,6 +74,22 @@ class StartController(QObject):
             communicate.starting_emulator.emit(True, self.tr(f'Start failed: {e}'), 0)
             return False
 
+    def _wait_until_device_ready(self):
+        wait_until = time.time() + self.start_timeout
+        while not self.exit_event.is_set():
+            og.device_manager.do_refresh(True)
+            error = self.check_device_error()
+            if error is None:
+                return True
+            logger.error(f'waiting for game to start error {error}')
+            remaining_time = wait_until - time.time()
+            if remaining_time <= 0:
+                communicate.starting_emulator.emit(True, self.tr('Start game timeout!'), 0)
+                return False
+            communicate.starting_emulator.emit(False, None, int(remaining_time))
+            time.sleep(2)
+        return False
+
     def start_device(self):
         device = og.device_manager.get_preferred_device()
         logger.info(f'start_device: {device}')
@@ -95,28 +111,14 @@ class StartController(QObject):
                 if not execute(path, arguments=args):
                     communicate.starting_emulator.emit(True, self.tr("Start game failed, please start game first"), 0)
                     return False
-                wait_until = time.time() + self.start_timeout
-                while not self.exit_event.is_set():
-                    og.device_manager.do_refresh(True)
-                    error = self.check_device_error()
-                    if error is None:
-                        break
-                    logger.error(f'waiting for game to start error {error}')
-                    remaining_time = wait_until - time.time()
-                    if remaining_time <= 0:
-                        communicate.starting_emulator.emit(True, self.tr('Start game timeout!'), 0)
-                        return False
-                    communicate.starting_emulator.emit(False, None, int(remaining_time))
-                    time.sleep(2)
+                if not self._wait_until_device_ready():
+                    return False
             else:
                 communicate.starting_emulator.emit(True,
                                                    self.tr('Game path does not exist, Please open game manually!'), 0)
                 return False
-        else:
-            error = self.check_device_error()
-            if error:
-                communicate.starting_emulator.emit(True, error, 0)
-                return False
+        elif not self._wait_until_device_ready():
+            return False
         communicate.starting_emulator.emit(True, None, 0)
         return True
 


### PR DESCRIPTION
## 问题描述

修复 ok-oldking/ok-wuthering-waves#1293。

使用 `ok-ww.exe -t N`（无界面直跑一次性任务）时，若鸣潮**已由外部预先启动**，进程常在约 0.3–1s 内退出，日志出现 `RuntimeError: Start task failed`，任务从未进入队列；若由 ok-ww **冷启动游戏**，则因存在轮询等待而正常。

## 根因

`StartController.start_device()` 在 `device['connected'] == True` 时仅调用**一次** `check_device_error()`。此时 WGC/窗口捕获常尚未就绪，会立即返回「未连接」类错误。

`connected == False`（冷启动）分支在 `starting game` 后会进入 `while + sleep(2)` 轮询，故能成功。

v3.3.29 起，`-t > 0` 走 `OK.start()` → `run_onetime_task()` → `do_start()` 无界面路径，不再经 GUI `MainWindow.showEvent`，该缺陷被稳定暴露。


## 修复方案

抽取 `_wait_until_device_ready()`，在「游戏已连接」与「冷启动后等待」两条路径共用同一套轮询逻辑（直至 `start_timeout`），与冷启动行为一致。

## 测试建议

- [ ] **路径 A（原失败）**：先手动启动鸣潮 → 执行 `ok-ww.exe -t 1`（或 `-t 1 -e`）→ 应出现 `waiting for game to start error` 后成功进入任务，而非秒退
- [ ] **路径 B（回归）**：结束鸣潮 → `ok-ww.exe -t 1` → 冷启动 + 轮询后任务正常
- [ ] **GUI**：手动点「开始」行为与修复前一致