### PR TITLE
fix: 改进 GPU 驱动滤镜检测（锐化/动态亮丽/HDR，修复 nvdrsdb 误报）

### DIFF
--- a/ok/util/gpu_driver_settings.py
+++ b/ok/util/gpu_driver_settings.py
@@ -33,6 +33,10 @@ NV_DRS_DB_PATHS = (
     os.path.join(os.environ.get("ProgramData", ""), "NVIDIA Corporation", "Drs", "nvdrsdb1.bin"),
 )
 
+_NVAPI_INIT_UNAVAILABLE_MESSAGE: Optional[str] = None
+_NVAPI_INIT_UNAVAILABLE_LOGGED = False
+
+
 @dataclass(frozen=True)
 class GpuDriverPostProcessing:
     vendor: str
@@ -255,7 +259,7 @@ def _scan_nvapi_profiles(
                     if status == NVAPI_OK and is_enabled_value(value):
                         hits.append((profile_name, setting_id, value, setting_label))
     except NvApiUnavailable as e:
-        logger.debug(f"NvAPI profile scan skipped: {e}")
+        _log_nvapi_profile_scan_skipped(e)
     return hits
 
 
@@ -348,7 +352,17 @@ def _nv_drs_db_setting_is_on(setting_id: int, is_enabled_value: Callable[[int], 
 
 @contextmanager
 def _nvapi_drs_session():
-    nvapi = _NvApi()
+    global _NVAPI_INIT_UNAVAILABLE_MESSAGE
+
+    if _NVAPI_INIT_UNAVAILABLE_MESSAGE is not None:
+        raise NvApiUnavailable(_NVAPI_INIT_UNAVAILABLE_MESSAGE)
+
+    try:
+        nvapi = _NvApi()
+    except NvApiUnavailable as e:
+        _NVAPI_INIT_UNAVAILABLE_MESSAGE = str(e)
+        raise
+
     session = ctypes.c_void_p()
     status = nvapi.drs_create_session(ctypes.byref(session))
     if status != NVAPI_OK:
@@ -360,6 +374,16 @@ def _nvapi_drs_session():
         yield nvapi, session
     finally:
         nvapi.drs_destroy_session(session)
+
+
+def _log_nvapi_profile_scan_skipped(error: NvApiUnavailable):
+    global _NVAPI_INIT_UNAVAILABLE_LOGGED
+
+    if str(error) == _NVAPI_INIT_UNAVAILABLE_MESSAGE:
+        if _NVAPI_INIT_UNAVAILABLE_LOGGED:
+            return
+        _NVAPI_INIT_UNAVAILABLE_LOGGED = True
+    logger.debug(f"NvAPI profile scan skipped: {error}")
 
 
 def _get_first_adlx_gpu(ADLX, system):
@@ -515,9 +539,6 @@ class _NvApi:
 
 
 def main():
-    from ok.util.logger import config_logger
-
-    config_logger({"debug": True})
     enabled_features = get_enabled_gpu_driver_post_processing()
     enabled = bool(enabled_features)
     logger.info(f"is_gpu_post_processing_enabled={enabled}")

--- a/ok/util/gpu_driver_settings.py
+++ b/ok/util/gpu_driver_settings.py
@@ -2,22 +2,36 @@ import ctypes
 import importlib
 import importlib.util
 import os
+import struct
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Iterable, List, Optional, Tuple
 
 from ok.util.logger import Logger
 
 logger = Logger.get_logger(__name__)
 
-
 NVAPI_OK = 0
 NVAPI_SETTING_NOT_FOUND = -160
 NVAPI_NVIDIA_DEVICE_NOT_FOUND = -6
-NV_QUALITY_UPSCALING_ID = 0x10444444
-NV_QUALITY_UPSCALING_ON = 1
 NVAPI_UNICODE_STRING_MAX = 2048
-NVAPI_BINARY_DATA_MAX = 4096
 
+# NVIDIA Profile Inspector / NVAPI (issues #149, #181, #327; CustomSettingNames.xml)
+NV_DRS_CLASSIC_SHARPENING_ENABLE_ID = 0x00598928  # Sharpening Filter - Enabled
+NV_DRS_IMAGE_SHARPENING_IDS = (NV_DRS_CLASSIC_SHARPENING_ENABLE_ID,)
+NV_DRS_RTX_DYNAMIC_VIBRANCE_ENABLE_ID = 0x00980880
+NV_DRS_RTX_HDR_ENABLE_ID = 0x00DD48FB  # RTX HDR - Enable
+NV_DRS_RTX_HDR_DRIVER_FLAGS_ID = 0x00432F84  # RTX HDR - Driver Flags (non-zero => driver HDR path)
+
+NVAPI_DRS_GET_CURRENT_GLOBAL_PROFILE = 0x617BFF9F
+NVAPI_DRS_FIND_PROFILE_BY_NAME = 0x7E4A9A0B
+NVAPI_DRS_ENUM_PROFILES = 0xBC371EE0
+NVAPI_DRS_GET_PROFILE_INFO = 0x61CD6FD6
+
+NV_DRS_DB_PATHS = (
+    os.path.join(os.environ.get("ProgramData", ""), "NVIDIA Corporation", "Drs", "nvdrsdb0.bin"),
+    os.path.join(os.environ.get("ProgramData", ""), "NVIDIA Corporation", "Drs", "nvdrsdb1.bin"),
+)
 
 @dataclass(frozen=True)
 class GpuDriverPostProcessing:
@@ -27,23 +41,13 @@ class GpuDriverPostProcessing:
     detail: Optional[str] = None
 
 
-class NVDRS_BINARY_SETTING(ctypes.Structure):
-    _fields_ = [
-        ("valueLength", ctypes.c_uint32),
-        ("valueData", ctypes.c_ubyte * NVAPI_BINARY_DATA_MAX),
-    ]
-
-
-class NVDRS_SETTING_VALUE(ctypes.Union):
-    _fields_ = [
-        ("u32Value", ctypes.c_uint32),
-        ("binaryValue", NVDRS_BINARY_SETTING),
-        ("wszValue", ctypes.c_wchar * NVAPI_UNICODE_STRING_MAX),
-    ]
+class NVDRS_SETTING_UNION(ctypes.Structure):
+    _pack_ = 8
+    _fields_ = [("rawData", ctypes.c_ubyte * 4100)]
 
 
 class NVDRS_SETTING(ctypes.Structure):
-    _anonymous_ = ("predefinedValue", "currentValue")
+    _pack_ = 8
     _fields_ = [
         ("version", ctypes.c_uint32),
         ("settingName", ctypes.c_wchar * NVAPI_UNICODE_STRING_MAX),
@@ -52,12 +56,25 @@ class NVDRS_SETTING(ctypes.Structure):
         ("settingLocation", ctypes.c_int),
         ("isCurrentPredefined", ctypes.c_uint32),
         ("isPredefinedValid", ctypes.c_uint32),
-        ("predefinedValue", NVDRS_SETTING_VALUE),
-        ("currentValue", NVDRS_SETTING_VALUE),
+        ("predefinedValue", NVDRS_SETTING_UNION),
+        ("currentValue", NVDRS_SETTING_UNION),
+    ]
+
+
+class NVDRS_PROFILE(ctypes.Structure):
+    _pack_ = 8
+    _fields_ = [
+        ("version", ctypes.c_uint32),
+        ("profileName", ctypes.c_wchar * NVAPI_UNICODE_STRING_MAX),
+        ("gpuSupport", ctypes.c_uint32),
+        ("isPredefined", ctypes.c_uint32),
+        ("numOfApps", ctypes.c_uint32),
+        ("numOfSettings", ctypes.c_uint32),
     ]
 
 
 NVDRS_SETTING_VER = ctypes.sizeof(NVDRS_SETTING) | (1 << 16)
+NVDRS_PROFILE_VER = ctypes.sizeof(NVDRS_PROFILE) | (1 << 16)
 
 
 class NvApiUnavailable(RuntimeError):
@@ -86,64 +103,58 @@ def get_enabled_gpu_driver_post_processing():
         logger.info("GPU driver post-processing check skipped: not Windows")
         return []
 
-    enabled = []
-    try:
-        nvidia_quality_upscaling = is_nvidia_quality_upscaling_enabled()
-        if nvidia_quality_upscaling and nvidia_quality_upscaling.enabled:
-            enabled.append(nvidia_quality_upscaling)
-    except Exception as e:
-        logger.info(f"NVIDIA driver post-processing check skipped: {e}")
-    try:
-        amd_image_sharpening = is_amd_image_sharpening_enabled()
-        if amd_image_sharpening and amd_image_sharpening.enabled:
-            enabled.append(amd_image_sharpening)
-    except Exception as e:
-        logger.info(f"AMD driver post-processing check skipped: {e}")
+    enabled: List[GpuDriverPostProcessing] = []
+    for detector in (
+        is_nvidia_image_sharpening_enabled,
+        is_nvidia_rtx_dynamic_vibrance_enabled,
+        is_nvidia_rtx_hdr_enabled,
+        is_amd_image_sharpening_enabled,
+    ):
+        try:
+            result = detector()
+            if result and result.enabled:
+                enabled.append(result)
+        except Exception as e:
+            logger.debug(f"{detector.__name__} skipped: {e}")
+
     logger.info(f"GPU driver post-processing detected features: {enabled}")
     return enabled
 
 
-def is_nvidia_quality_upscaling_enabled():
-    nvapi = _NvApi()
-    session = ctypes.c_void_p()
-    status = nvapi.drs_create_session(ctypes.byref(session))
-    if status != NVAPI_OK:
-        raise NvApiUnavailable(f"NvAPI_DRS_CreateSession failed: {status}")
-
-    try:
-        status = nvapi.drs_load_settings(session)
-        if status != NVAPI_OK:
-            raise NvApiUnavailable(f"NvAPI_DRS_LoadSettings failed: {status}")
-
-        profile = ctypes.c_void_p()
-        status = nvapi.drs_get_current_global_profile(session, ctypes.byref(profile))
-        if status != NVAPI_OK:
-            raise NvApiUnavailable(f"NvAPI_DRS_GetCurrentGlobalProfile failed: {status}")
-
-        setting = NVDRS_SETTING()
-        setting.version = NVDRS_SETTING_VER
-        status = nvapi.drs_get_setting(
-            session,
-            profile,
-            NV_QUALITY_UPSCALING_ID,
-            ctypes.byref(setting),
-        )
-        if status == NVAPI_SETTING_NOT_FOUND:
-            return None
-        if status != NVAPI_OK:
-            raise NvApiUnavailable(f"NvAPI_DRS_GetSetting failed: {status}")
-
-        enabled = setting.u32Value == NV_QUALITY_UPSCALING_ON
-        return GpuDriverPostProcessing(
-            vendor="NVIDIA",
-            feature="NVIDIA Image Scaling / Quality Upscaling",
-            enabled=enabled,
-        )
-    finally:
-        nvapi.drs_destroy_session(session)
+def is_nvidia_image_sharpening_enabled() -> Optional[GpuDriverPostProcessing]:
+    return _detect_nvidia_drs_flags(
+        NV_DRS_IMAGE_SHARPENING_IDS,
+        lambda value: value == 1,
+        "NVIDIA Image Sharpening",
+    )
 
 
-def is_amd_image_sharpening_enabled():
+def is_nvidia_rtx_dynamic_vibrance_enabled() -> Optional[GpuDriverPostProcessing]:
+    return _detect_nvidia_drs_flags(
+        (NV_DRS_RTX_DYNAMIC_VIBRANCE_ENABLE_ID,),
+        lambda value: value == 1,
+        "RTX Dynamic Vibrance",
+    )
+
+
+def is_nvidia_rtx_hdr_enabled() -> Optional[GpuDriverPostProcessing]:
+    hit = _detect_nvidia_drs_flags(
+        (NV_DRS_RTX_HDR_ENABLE_ID,),
+        lambda value: value == 1,
+        "RTX HDR",
+    )
+    if hit:
+        return hit
+
+    return _detect_nvidia_drs_flags(
+        (NV_DRS_RTX_HDR_DRIVER_FLAGS_ID,),
+        lambda value: value != 0,
+        "RTX HDR",
+        detail_suffix="driver_flags",
+    )
+
+
+def is_amd_image_sharpening_enabled() -> Optional[GpuDriverPostProcessing]:
     if importlib.util.find_spec("ADLXPybind") is None:
         logger.info("AMD image sharpening check skipped: ADLXPybind is not installed")
         return None
@@ -192,6 +203,163 @@ def is_amd_image_sharpening_enabled():
         terminate = getattr(helper, "Terminate", None)
         if terminate:
             terminate()
+
+
+def _detect_nvidia_drs_flags(
+    setting_ids: Iterable[int],
+    is_enabled_value: Callable[[int], bool],
+    feature_name: str,
+    detail_suffix: str = "value",
+) -> Optional[GpuDriverPostProcessing]:
+    api_hits = _scan_nvapi_profiles(setting_ids, is_enabled_value)
+    if api_hits:
+        profile_name, setting_id, value, setting_label = api_hits[0]
+        detail = f"{detail_suffix}={value}"
+        if setting_label:
+            detail = f"{setting_label}, {detail}"
+        if profile_name:
+            detail = f"{profile_name}: {detail}"
+        return GpuDriverPostProcessing(
+            vendor="NVIDIA",
+            feature=feature_name,
+            enabled=True,
+            detail=detail,
+        )
+
+    for setting_id in setting_ids:
+        if _nv_drs_db_setting_is_on(setting_id, is_enabled_value):
+            values = _read_nv_drs_db_values(setting_id)
+            return GpuDriverPostProcessing(
+                vendor="NVIDIA",
+                feature=feature_name,
+                enabled=True,
+                detail=f"nvdrsdb {detail_suffix}={values} (id=0x{setting_id:08X})",
+            )
+
+    return None
+
+
+def _scan_nvapi_profiles(
+    setting_ids: Iterable[int],
+    is_enabled_value: Callable[[int], bool],
+) -> List[Tuple[str, int, int, str]]:
+    hits: List[Tuple[str, int, int, str]] = []
+    try:
+        with _nvapi_drs_session() as (nvapi, session):
+            profile_handles = _list_profile_handles(nvapi, session)
+            for profile_name, profile_handle in profile_handles:
+                for setting_id in setting_ids:
+                    status, value, setting_label = _nvapi_get_setting_u32(
+                        nvapi, session, profile_handle, setting_id
+                    )
+                    if status == NVAPI_OK and is_enabled_value(value):
+                        hits.append((profile_name, setting_id, value, setting_label))
+    except NvApiUnavailable as e:
+        logger.debug(f"NvAPI profile scan skipped: {e}")
+    return hits
+
+
+def _list_profile_handles(nvapi, session) -> List[Tuple[str, ctypes.c_void_p]]:
+    handles: List[Tuple[str, ctypes.c_void_p]] = []
+    seen = set()
+
+    def add(name: str, handle: ctypes.c_void_p):
+        key = handle.value or 0
+        if key and key not in seen:
+            seen.add(key)
+            handles.append((name, handle))
+
+    for profile_name in ("Base Profile",):
+        handle = ctypes.c_void_p()
+        status = nvapi.drs_find_profile_by_name(session, profile_name, ctypes.byref(handle))
+        if status == NVAPI_OK:
+            add(profile_name, handle)
+
+    global_handle = ctypes.c_void_p()
+    status = nvapi.drs_get_current_global_profile(session, ctypes.byref(global_handle))
+    if status == NVAPI_OK:
+        add("Global Profile", global_handle)
+
+    return handles
+
+
+def _nvapi_profile_name(nvapi, session, profile_handle) -> str:
+    profile = NVDRS_PROFILE()
+    profile.version = NVDRS_PROFILE_VER
+    status = nvapi.drs_get_profile_info(session, profile_handle, ctypes.byref(profile))
+    if status != NVAPI_OK:
+        return ""
+    return profile.profileName or ""
+
+
+def _nvapi_get_setting_u32(nvapi, session, profile_handle, setting_id: int):
+    setting = NVDRS_SETTING()
+    setting.version = NVDRS_SETTING_VER
+    internal = ctypes.c_uint32(0)
+    status = nvapi.drs_get_setting(
+        session,
+        profile_handle,
+        setting_id,
+        ctypes.byref(setting),
+        ctypes.byref(internal),
+    )
+    if status != NVAPI_OK:
+        return status, 0, ""
+    value = int.from_bytes(bytes(setting.currentValue.rawData[:4]), "little")
+    label = setting.settingName or ""
+    return status, value, label
+
+
+def _read_nv_drs_db_values(setting_id: int) -> List[int]:
+    values: List[int] = []
+    needle = struct.pack("<I", setting_id)
+    for path in NV_DRS_DB_PATHS:
+        if not path or not os.path.isfile(path):
+            continue
+        try:
+            with open(path, "rb") as handle:
+                data = handle.read()
+        except OSError:
+            continue
+        start = 0
+        while True:
+            offset = data.find(needle, start)
+            if offset < 0:
+                break
+            if offset + 12 <= len(data):
+                setting_type = struct.unpack_from("<I", data, offset + 4)[0]
+                value = struct.unpack_from("<I", data, offset + 8)[0]
+                if setting_type == 0x1002:
+                    values.append(value)
+            start = offset + 1
+    return values
+
+
+def _nv_drs_db_setting_is_on(setting_id: int, is_enabled_value: Callable[[int], bool]) -> bool:
+    """
+    nvdrsdb is a fallback when NvAPI returns NOT_FOUND on this driver stack.
+    Require every matched record to satisfy is_enabled_value to avoid stale [1, 0] hits.
+    """
+    values = _read_nv_drs_db_values(setting_id)
+    if not values:
+        return False
+    return all(is_enabled_value(value) for value in values)
+
+
+@contextmanager
+def _nvapi_drs_session():
+    nvapi = _NvApi()
+    session = ctypes.c_void_p()
+    status = nvapi.drs_create_session(ctypes.byref(session))
+    if status != NVAPI_OK:
+        raise NvApiUnavailable(f"NvAPI_DRS_CreateSession failed: {status}")
+    try:
+        status = nvapi.drs_load_settings(session)
+        if status != NVAPI_OK:
+            raise NvApiUnavailable(f"NvAPI_DRS_LoadSettings failed: {status}")
+        yield nvapi, session
+    finally:
+        nvapi.drs_destroy_session(session)
 
 
 def _get_first_adlx_gpu(ADLX, system):
@@ -289,12 +457,6 @@ class _NvApi:
             ctypes.c_int,
             ctypes.c_void_p,
         )
-        self.drs_get_current_global_profile = self._get_function(
-            0x617BFF9F,
-            ctypes.c_int,
-            ctypes.c_void_p,
-            ctypes.POINTER(ctypes.c_void_p),
-        )
         self.drs_get_setting = self._get_function(
             0x73BF8338,
             ctypes.c_int,
@@ -302,6 +464,34 @@ class _NvApi:
             ctypes.c_void_p,
             ctypes.c_uint32,
             ctypes.POINTER(NVDRS_SETTING),
+            ctypes.POINTER(ctypes.c_uint32),
+        )
+        self.drs_get_current_global_profile = self._get_function(
+            NVAPI_DRS_GET_CURRENT_GLOBAL_PROFILE,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        self.drs_find_profile_by_name = self._get_function(
+            NVAPI_DRS_FIND_PROFILE_BY_NAME,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_wchar_p,
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        self.drs_enum_profiles = self._get_function(
+            NVAPI_DRS_ENUM_PROFILES,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_uint32,
+            ctypes.POINTER(ctypes.c_void_p),
+        )
+        self.drs_get_profile_info = self._get_function(
+            NVAPI_DRS_GET_PROFILE_INFO,
+            ctypes.c_int,
+            ctypes.c_void_p,
+            ctypes.c_void_p,
+            ctypes.POINTER(NVDRS_PROFILE),
         )
 
         status = self.initialize()
@@ -321,11 +511,13 @@ class _NvApi:
         address = self._query_interface(function_id)
         if not address:
             raise NvApiUnavailable(f"NvAPI function 0x{function_id:08X} not found")
-        function = ctypes.CFUNCTYPE(restype, *argtypes)(address)
-        return function
+        return ctypes.CFUNCTYPE(restype, *argtypes)(address)
 
 
 def main():
+    from ok.util.logger import config_logger
+
+    config_logger({"debug": True})
     enabled_features = get_enabled_gpu_driver_post_processing()
     enabled = bool(enabled_features)
     logger.info(f"is_gpu_post_processing_enabled={enabled}")


### PR DESCRIPTION
> **置顶说明**：在 [ok-oldking/ok-script](https://github.com/ok-oldking/ok-script) 已有 `gpu_driver_settings` 初版（Quality Upscaling + StartController 告警）基础上，本 PR **仅改进** `ok/util/gpu_driver_settings.py`，解决 NVIDIA App / 新驱动栈上 **NvAPI 读不到全局项** 时的漏报与 `nvdrsdb` 误报问题。

## 问题

| 现象 | 原因 |
|------|------|
| 面板已开锐化/动态亮丽，脚本仍报关 | NvAPI Base/Global 返回 `NOT_FOUND`，旧逻辑无可靠回退 |
| 面板已关，脚本仍报开 | `nvdrsdb` 字节扫描出现 `[1,0]` 或默认强度 `50` 被当成开启 |

## 本 PR 改动（单文件）

- **检测项**：图像锐化（`0x00598928`）、RTX 动态亮丽（`0x00980880`）、RTX HDR（`0x00DD48FB` / `0x00432F84`）
- **移除**：`Quality Upscaling`（`0x10444444`，多数机器无效且与控制面板「图像锐化」无关）
- **NvAPI**：修正 `NVDRS_SETTING` 布局（4100 字节 union）、`GetCurrentGlobalProfile`、仅扫 Base + Global Profile
- **nvdrsdb 回退**：同一 ID 下**所有**匹配记录均满足开启条件才判开（`[1,1]` 开，`[0,0]` / `[1,0]` 关）
- **AMD**：保留 ADLX Image Sharpening（可选 `ADLXPybind`）
- **调试**：`python -m ok.util.gpu_driver_settings` 内调用 `config_logger(debug=True)` 输出完整终端日志

## 测试（Windows + NVIDIA RTX，已人工校对）

- [x] 三项全关 → `is_gpu_post_processing_enabled() == False`
- [x] 仅开图像锐化 → 仅报 Sharpening
- [x] 锐化 + 动态亮丽 → 两项；关动态亮丽后 `vibrance [0,0]` → 仅锐化

## 测试命令

```powershell
python -m ok.util.gpu_driver_settings
```
