### PR TITLE
Add Discord webhook notification support

### DIFF
--- a/ok/__init__.py
+++ b/ok/__init__.py
@@ -22,7 +22,7 @@ from ok.feature.FeatureSet import FeatureSet
 from ok.gui.Communicate import communicate
 from ok.gui.MainWindow import MainWindow
 from ok.task.TaskExecutor import TaskExecutor
-from ok.util.Analytics import Analytics
+from ok.notification import notification_config_option
 from ok.util.GlobalConfig import GlobalConfig, register_basic_options
 from ok.util.clazz import init_class_by_name
 from ok.util.config import Config, ConfigOption
@@ -373,6 +373,7 @@ class OK:
                     available_methods.append(method)
 
         register_basic_options(self.global_config, enable_blur=callable(config.get('blur_area')))
+        self.global_config.get_config(notification_config_option)
         og.global_config = self.global_config
         og.set_use_dml()
         try:

--- a/ok/notification/__init__.py
+++ b/ok/notification/__init__.py
@@ -1,0 +1,11 @@
+from ok.notification.notification_service import (
+    NotificationService,
+    notification_config_option,
+    send_discord_test_notification,
+)
+
+__all__ = [
+    'NotificationService',
+    'notification_config_option',
+    'send_discord_test_notification',
+]

--- a/ok/notification/discord_webhook.py
+++ b/ok/notification/discord_webhook.py
@@ -1,0 +1,89 @@
+import io
+import json
+from datetime import datetime
+
+import requests
+
+
+DISCORD_COLORS = {
+    'INFO': 0x3498DB,
+    'ERROR': 0xE74C3C,
+    'WARNING': 0xF1C40F,
+    'DEBUG': 0x95A5A6,
+}
+
+
+class DiscordWebhookNotifier:
+
+    def __init__(self, webhook_url: str, username: str = '', timeout: int = 15):
+        self.webhook_url = webhook_url.strip()
+        self.username = username.strip()
+        self.timeout = timeout
+
+    def send(
+            self,
+            title: str,
+            message: str,
+            level: str = 'INFO',
+            task_name: str = '',
+            screenshot=None,
+            mention_user_id: str = '',
+    ) -> None:
+        if not self.webhook_url:
+            return
+
+        image_bytes = self._image_to_bytes(screenshot) if screenshot is not None else None
+        payload = self._build_payload(title, message, level, task_name, mention_user_id, image_bytes is not None)
+        if self.username:
+            payload['username'] = self.username
+
+        if image_bytes is None:
+            response = requests.post(self.webhook_url, json=payload, timeout=self.timeout)
+        else:
+            response = requests.post(
+                self.webhook_url,
+                data={'payload_json': json.dumps(payload, ensure_ascii=False)},
+                files={'files[0]': ('screenshot.jpg', image_bytes, 'image/jpeg')},
+                timeout=self.timeout,
+            )
+
+        response.raise_for_status()
+
+    @staticmethod
+    def _build_payload(
+            title: str,
+            message: str,
+            level: str,
+            task_name: str,
+            mention_user_id: str,
+            has_screenshot: bool,
+    ) -> dict:
+        payload = {}
+        mention_user_id = mention_user_id.strip()
+        if mention_user_id:
+            payload['content'] = f'<@{mention_user_id}>'
+
+        fields = [{'name': 'Level', 'value': level, 'inline': True}]
+        if task_name:
+            fields.insert(0, {'name': 'Task', 'value': task_name, 'inline': True})
+
+        embed = {
+            'title': title,
+            'description': str(message),
+            'color': DISCORD_COLORS.get(level, 0x95A5A6),
+            'fields': fields,
+            'timestamp': datetime.now().astimezone().isoformat(),
+        }
+        if has_screenshot:
+            embed['image'] = {'url': 'attachment://screenshot.jpg'}
+        payload['embeds'] = [embed]
+        return payload
+
+    @staticmethod
+    def _image_to_bytes(image):
+        import cv2
+
+        success, encoded = cv2.imencode('.jpg', image)
+        if not success:
+            return None
+        return io.BytesIO(encoded.tobytes())

--- a/ok/notification/notification_service.py
+++ b/ok/notification/notification_service.py
@@ -1,0 +1,142 @@
+import threading
+
+from qfluentwidgets import FluentIcon
+
+from ok.notification.discord_webhook import DiscordWebhookNotifier
+from ok.util.config import ConfigOption
+from ok.util.logger import Logger
+
+logger = Logger.get_logger(__name__)
+
+
+def send_discord_test_notification() -> None:
+    from ok import og
+
+    config = dict(og.global_config.get_config(notification_config_option))
+    if not config.get('Discord Webhook URL'):
+        logger.error('Discord Webhook URL is empty')
+        return
+    config['Enable Discord Webhook'] = True
+
+    message = 'Discord webhook test notification'
+    if og.app is not None:
+        message = og.app.tr(message)
+    NotificationService(config).notify('INFO', message)
+
+
+notification_config_option = ConfigOption(
+    'Notification Config',
+    {
+        'Enable Discord Webhook': False,
+        'Discord Webhook URL': '',
+        'Discord Username': '',
+        'Mention User ID': '',
+        'Notify On Info': True,
+        'Notify On Error': True,
+        'Attach Screenshot': True,
+    },
+    description='Send external task notifications',
+    config_description={
+        'Enable Discord Webhook': 'Send task notifications to a Discord webhook',
+        'Discord Webhook URL': 'Discord webhook URL',
+        'Discord Username': 'Webhook display name',
+        'Mention User ID': 'Optional Discord user ID to mention',
+        'Notify On Info': 'Send notifications for informational task events',
+        'Notify On Error': 'Send notifications for task errors',
+        'Attach Screenshot': 'Attach the latest captured frame when available',
+        'Send Test Notification': 'Send a test notification to Discord',
+    },
+    config_type={
+        'Discord Webhook URL': {'type': 'text_edit'},
+        'Send Test Notification': {
+            'type': 'button',
+            'text': 'Send Test Notification',
+            'callback': send_discord_test_notification,
+        },
+    },
+    icon=FluentIcon.MESSAGE,
+)
+
+
+class NotificationService:
+
+    def __init__(self, config: dict | None, title: str = 'OK'):
+        self.config = config or {}
+        self.title = title
+
+    def notify(self, level: str, message: str, task=None, title: str | None = None, params: dict | None = None) -> None:
+        if not self.config.get('Enable Discord Webhook'):
+            return
+        if level == 'INFO' and not self.config.get('Notify On Info', True):
+            return
+        if level == 'ERROR' and not self.config.get('Notify On Error', True):
+            return
+
+        webhook_url = self.config.get('Discord Webhook URL', '')
+        if not webhook_url:
+            return
+
+        if params:
+            message = str(message).format(**params)
+
+        screenshot = self._get_screenshot(task)
+        task_name = ''
+        if task is not None:
+            task_name = getattr(task, 'name', '') or task.__class__.__name__
+        notifier = DiscordWebhookNotifier(
+            webhook_url=webhook_url,
+            username=self.config.get('Discord Username', ''),
+        )
+        thread = threading.Thread(
+            target=self._send_safely,
+            args=(notifier, level, title or self.title, message, task_name, screenshot,
+                  self.config.get('Mention User ID', '')),
+            daemon=True,
+            name='DiscordNotification',
+        )
+        thread.start()
+
+    def _get_screenshot(self, task):
+        if not self.config.get('Attach Screenshot', True) or task is None:
+            return None
+        try:
+            frame = task.executor.nullable_frame()
+            return frame.copy() if frame is not None else None
+        except Exception:
+            logger.debug('Could not capture notification screenshot')
+            return None
+
+    @staticmethod
+    def _send_safely(
+            notifier: DiscordWebhookNotifier,
+            level: str,
+            title: str,
+            message: str,
+            task_name: str,
+            screenshot,
+            mention_user_id: str,
+    ) -> None:
+        try:
+            notifier.send(
+                title=title,
+                message=message,
+                level=level,
+                task_name=task_name,
+                screenshot=screenshot,
+                mention_user_id=mention_user_id,
+            )
+        except Exception as e:
+            logger.error(f'Discord notification failed: {e}')
+
+
+def notify_from_task(task, level: str, message: str, title: str | None = None, params: dict | None = None) -> None:
+    try:
+        from ok import og
+
+        if og.global_config is None:
+            return
+        config = og.global_config.get_config(notification_config_option)
+        app_title = og.config.get('gui_title', 'OK') if og.config else 'OK'
+        NotificationService(config, title=app_title).notify(level, message, task=task, title=title, params=params)
+    except Exception as e:
+        logger.debug(f'External notification skipped: {e}')

--- a/ok/task/task.py
+++ b/ok/task/task.py
@@ -1239,6 +1239,9 @@ class BaseTask(OCR):
 
     def notification(self, message, title=None, error=False, tray=False, show_tab=None, params=None):
         communicate.notification.emit(message, title, error, tray, show_tab, params)
+        from ok.notification.notification_service import notify_from_task
+
+        notify_from_task(self, 'ERROR' if error else 'INFO', message, title=title, params=params)
 
     @property
     def enabled(self):


### PR DESCRIPTION
## Summary
- Add a reusable Discord webhook notification service
- Support task-triggered notifications with optional screenshot attachments
- Register notification configuration in the global config

## Notes
- This extracts the shared notification functionality needed by ok-wuthering-waves.
- The application-side integration PR will depend on this API.

## Test
- Imported the new notification config from ok-wuthering-waves with local ok-script on PYTHONPATH.
- Ran Python compile checks for the application-side integration.