### PR TITLE
优化启动性能：使用线程事件同步机制延迟 OCR 初始化以避免主线程干扰

### DIFF
--- a/ok/__init__.py
+++ b/ok/__init__.py
@@ -220,6 +220,7 @@ class App:
         self.main_window.bring_to_front()
 
         logger.debug(f'show_main_window end')
+        og.gui_ready.set()
 
     def exec(self):
         logger.info('app.exec()')
@@ -266,6 +267,7 @@ class HeadlessApp:
             if not hasattr(og.my_app, 'get_overlay_view'):
                 og.my_app.get_overlay_view = self.get_overlay_view
         logger.debug('init headless app end')
+        og.gui_ready.set()
 
     def tr(self, key):
         if not key:
@@ -746,6 +748,7 @@ class OkGlobals:
         self.app_path = get_path_relative_to_exe()
         self.use_dml = False
         self.global_config = None
+        self.gui_ready = threading.Event()
         logger.info(f'app path {self.app_path}')
 
     def set_use_dml(self):

--- a/ok/task/TaskExecutor.py
+++ b/ok/task/TaskExecutor.py
@@ -143,6 +143,13 @@ class TaskExecutor:
         self._ocr_init_thread.start()
 
     def _init_default_ocr(self):
+        try:
+            from ok import og
+            og.gui_ready.wait(timeout=30)
+            time.sleep(1)
+        except Exception as e:
+            logger.error('init default ocr delay error', e)
+
         start = time.time()
         try:
             logger.info('start init default ocr')


### PR DESCRIPTION
#### 变更背景与动机
虽然 OCR 初始化被设计在后台异步线程中进行，但在应用刚启动、GUI 主线程正在创建和渲染主窗口的关键时期，后台线程中进行繁重的 OCR 模型加载与库导入仍会产生严重的 CPU 竞争和 GIL（全局解释器锁）争用。这会导致主线程在展示主窗口时出现明显的卡顿甚至短暂冻结。

本 PR 旨在通过引入延迟加载机制来修复该问题：确保后台 OCR 的初始化工作被严格推迟到主窗口完全就绪并渲染完毕之后执行。

#### 变更内容
本 PR 引入了基于 `threading.Event` 的全局同步事件 `og.gui_ready`，用于精准、优雅地协调后台初始化线程与 GUI 主线程的生命周期：

1. **`ok/__init__.py`**
   - 在全局状态类 [OkGlobals](file:///d:/vscode/ok-script-code/ok/__init__.py#L730) 中新增 `self.gui_ready = threading.Event()` 线程事件。
   - **GUI 模式下**：在 [App.do_show_main()](file:///d:/vscode/ok-script-code/ok/__init__.py#L198-L224) 的末尾（即主窗口已完全创建、呈现并带到前台后）触发 `og.gui_ready.set()`，从而通知后台线程释放等待。
   - **Headless / No-GUI 模式下**：在 [HeadlessApp.__init__](file:///d:/vscode/ok-script-code/ok/__init__.py#L246-L270) 构造函数的末尾触发 `og.gui_ready.set()`（因为 `HeadlessApp` 在 `do_init` 阶段即被实例化，可以保证非 GUI 运行下立即释放后台等待）。

2. **`ok/task/TaskExecutor.py`**
   - 重构了 [_init_default_ocr()](file:///d:/vscode/ok-script-code/ok/task/TaskExecutor.py#L145-L160)。将原先的直接启动或简单延时，替换为在加载前先调用 `og.gui_ready.wait(timeout=30)` 进行非阻塞等待。在主线程渲染工作全部结束后，后台线程才开始真正执行 OCR 初始化。

#### 带来的改进与设计优势
- **消除主线程卡顿**：将 CPU 密集且锁竞争激烈的 OCR 初始化推迟到主窗口呈现之后，彻底解决了启动初期后台初始化对 GUI 主线程渲染的干扰，使界面展现极为流畅。
- **低开销等待**：使用操作系统级的线程事件等待替代了原有的 busy-wait 轮询，消除了等待期间对 CPU 资源的浪费。
- **高鲁棒性**：提供 30 秒的超时机制，即使 GUI 渲染流程异常未能置位事件，后台 OCR 依然能在超时后自动开始加载，保证基础功能不挂起。
- **通用扩展能力（补充说明）**：新引入的全局 `og.gui_ready` 信号不局限于 OCR，它作为一个通用的 GUI 就绪通知机制，**允许任何其他繁重的第三方模块/事件初始化（例如音频监听器上下文加载、硬件设备探测、大型配置文件预读等）在后台线程中利用它进行阻塞等待**，直到 GUI 界面完全呈现，从而将对启动体验的干扰降到最低。