### PR TITLE
新增下拉多选配置组件

### DIFF
--- a/ok/gui/tasks/ConfigCard.py
+++ b/ok/gui/tasks/ConfigCard.py
@@ -140,6 +140,9 @@ class ConfigContentMixin:
             switch_button = getattr(widget, 'switch_button', None)
             if switch_button is not None:
                 switch_button.checkedChanged.connect(self.__apply_sub_config_visibility)
+            multi_selection_changed = getattr(widget, 'multi_selection_changed', None)
+            if multi_selection_changed is not None:
+                multi_selection_changed.connect(self.__apply_sub_config_visibility)
 
         self.__apply_sub_config_visibility()
 
@@ -210,9 +213,20 @@ class ConfigContentMixin:
 
     def __get_active_sub_config_keys(self, key):
         try:
-            config_keys = self.sub_configs_rules.get(key, {}).get(self.config.get(key), [])
+            config_value = self.config.get(key)
         except TypeError:
             return []
+
+        rule = self.sub_configs_rules.get(key, {})
+        if isinstance(config_value, list):
+            config_keys = []
+            for selected_value in config_value:
+                for config_key in rule.get(selected_value, []):
+                    if config_key not in config_keys:
+                        config_keys.append(config_key)
+        else:
+            config_keys = rule.get(config_value, [])
+
         return [
             config_key for config_key in config_keys
             if config_key in self.config_widget_by_key
@@ -296,9 +310,18 @@ class ConfigContentMixin:
                 return False
 
             try:
-                visible_config_keys = rule.get(self.config.get(parent_key), [])
+                parent_value = self.config.get(parent_key)
             except TypeError:
                 visible_config_keys = []
+            else:
+                if isinstance(parent_value, list):
+                    visible_config_keys = []
+                    for selected_value in parent_value:
+                        for config_key in rule.get(selected_value, []):
+                            if config_key not in visible_config_keys:
+                                visible_config_keys.append(config_key)
+                else:
+                    visible_config_keys = rule.get(parent_value, [])
 
             if key not in visible_config_keys:
                 return False

--- a/ok/gui/tasks/ConfigItemFactory.py
+++ b/ok/gui/tasks/ConfigItemFactory.py
@@ -5,6 +5,7 @@ from ok.gui.tasks.LabelAndFileSelector import LabelAndFileSelector
 from ok.gui.tasks.LabelAndGlobal import LabelAndGlobal
 from ok.gui.tasks.LabelAndLineEdit import LabelAndLineEdit
 from ok.gui.tasks.LabelAndMultiSelection import LabelAndMultiSelection
+from ok.gui.tasks.LabelAndMultiSelectionDropDown import LabelAndMultiSelectionDropDown
 from ok.gui.tasks.LabelAndSpinBox import LabelAndSpinBox
 from ok.gui.tasks.LabelAndSwitchButton import LabelAndSwitchButton
 from ok.gui.tasks.LabelAndTextEdit import LabelAndTextEdit
@@ -41,6 +42,8 @@ def config_widget(config_type, config_desc, config, key, value, task):
             return LabelAndDropDown(config_desc, the_type['options'], config, key)
         elif resolved_type == 'multi_selection':
             return LabelAndMultiSelection(config_desc, the_type['options'], config, key)
+        elif resolved_type == 'multi_selection_dropdown':
+            return LabelAndMultiSelectionDropDown(config_desc, the_type['options'], config, key)
         elif resolved_type == 'global':
             config = task.get_global_config(key)
             desc = task.get_global_config_desc(key)

--- a/ok/gui/tasks/LabelAndMultiSelectionDropDown.py
+++ b/ok/gui/tasks/LabelAndMultiSelectionDropDown.py
@@ -1,0 +1,96 @@
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QAction, QFontMetrics
+from PySide6.QtWidgets import QStyle, QStyleOptionViewItem
+from qfluentwidgets import DropDownPushButton, IndicatorMenuItemDelegate, RoundMenu
+
+from ok import og
+from ok.gui.tasks.ConfigLabelAndWidget import ConfigLabelAndWidget
+
+
+class MultiSelectIndicatorMenuItemDelegate(IndicatorMenuItemDelegate):
+    def paint(self, painter, option, index):
+        action = index.data(Qt.UserRole)
+        if isinstance(action, QAction) and action.isChecked():
+            option = QStyleOptionViewItem(option)
+            option.state |= QStyle.State_Selected
+        super().paint(painter, option, index)
+
+
+class MultiSelectDropDownMenu(RoundMenu):
+    def _onItemClicked(self, item):
+        action = item.data(Qt.UserRole)
+        if action not in self._actions or not action.isEnabled():
+            return
+        action.trigger()
+
+
+class LabelAndMultiSelectionDropDown(ConfigLabelAndWidget):
+    multi_selection_changed = Signal()
+
+    def __init__(self, config_desc, options, config, key: str):
+        super().__init__(config_desc, config, key)
+        self.tr_dict = {}
+        self.tr_options = []
+        self.user_action = True
+        self.actions = []
+
+        for option in options:
+            tr = og.app.tr(option)
+            self.tr_options.append(tr)
+            self.tr_dict[tr] = option
+
+        self.menu = MultiSelectDropDownMenu(parent=self)
+        self.menu.view.setItemDelegate(MultiSelectIndicatorMenuItemDelegate())
+        self.menu.view.setObjectName('comboListWidget')
+        self.menu.setItemHeight(33)
+
+        self.drop_down = DropDownPushButton(self)
+        self.drop_down.setMenu(self.menu)
+        self.__set_drop_down_width()
+
+        for option in self.tr_options:
+            action = QAction(option, self)
+            action.setCheckable(True)
+            action.triggered.connect(self.check_changed)
+            self.actions.append(action)
+            self.menu.addAction(action)
+
+        self.add_widget(self.drop_down, stretch=0)
+        self.update_value()
+
+    def __set_drop_down_width(self):
+        fm = QFontMetrics(self.drop_down.font())
+        max_width = 0
+        for option in self.tr_options:
+            max_width = max(max_width, fm.horizontalAdvance(option))
+        self.drop_down.setMinimumWidth(max(180, max_width + 50))
+
+    def check_changed(self, *args):
+        options = [
+            self.tr_dict.get(action.text())
+            for action in self.actions
+            if action.isChecked()
+        ]
+        if self.user_action:
+            self.update_config(options)
+            self.update_button_text()
+            self.multi_selection_changed.emit()
+
+    def update_value(self):
+        self.user_action = False
+        selected_options = self.config.get(self.key) or []
+        for action in self.actions:
+            action.setChecked(self.tr_dict[action.text()] in selected_options)
+        self.user_action = True
+        self.update_button_text()
+
+    def update_button_text(self):
+        selected = [
+            action.text()
+            for action in self.actions
+            if action.isChecked()
+        ]
+        if not selected:
+            self.drop_down.setText(og.app.tr("None"))
+        else:
+            self.drop_down.setText(" / ".join(selected))

--- a/ok/gui/tasks/LabelAndMultiSelectionDropDown.py
+++ b/ok/gui/tasks/LabelAndMultiSelectionDropDown.py
@@ -1,27 +1,39 @@
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import Signal
 from PySide6.QtGui import QAction, QFontMetrics
-from PySide6.QtWidgets import QStyle, QStyleOptionViewItem
-from qfluentwidgets import DropDownPushButton, IndicatorMenuItemDelegate, RoundMenu
+from PySide6.QtWidgets import QAbstractItemView
+from qfluentwidgets import DropDownPushButton
+from qfluentwidgets.components.widgets.combo_box import ComboBoxMenu
 
 from ok import og
 from ok.gui.tasks.ConfigLabelAndWidget import ConfigLabelAndWidget
 
 
-class MultiSelectIndicatorMenuItemDelegate(IndicatorMenuItemDelegate):
-    def paint(self, painter, option, index):
-        action = index.data(Qt.UserRole)
-        if isinstance(action, QAction) and action.isChecked():
-            option = QStyleOptionViewItem(option)
-            option.state |= QStyle.State_Selected
-        super().paint(painter, option, index)
+class MultiSelectComboBoxMenu(ComboBoxMenu):
+    item_toggled = Signal(int)
 
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.view.setSelectionMode(QAbstractItemView.MultiSelection)
+        self._selected_rows = set()
 
-class MultiSelectDropDownMenu(RoundMenu):
+    def set_selected_rows(self, rows):
+        self._selected_rows = set(rows)
+        self.sync_selection()
+
+    def sync_selection(self):
+        for row in range(self.view.count()):
+            self.view.item(row).setSelected(row in self._selected_rows)
+
     def _onItemClicked(self, item):
-        action = item.data(Qt.UserRole)
-        if action not in self._actions or not action.isEnabled():
+        row = self.view.row(item)
+        action = item.data(0x0100)
+        if row < 0 or action not in self._actions or not action.isEnabled():
             return
-        action.trigger()
+        self.item_toggled.emit(row)
+
+    def exec(self, *args, **kwargs):
+        self.sync_selection()
+        return super().exec(*args, **kwargs)
 
 
 class LabelAndMultiSelectionDropDown(ConfigLabelAndWidget):
@@ -31,29 +43,23 @@ class LabelAndMultiSelectionDropDown(ConfigLabelAndWidget):
         super().__init__(config_desc, config, key)
         self.tr_dict = {}
         self.tr_options = []
+        self.selected_rows = set()
         self.user_action = True
-        self.actions = []
 
         for option in options:
             tr = og.app.tr(option)
             self.tr_options.append(tr)
             self.tr_dict[tr] = option
 
-        self.menu = MultiSelectDropDownMenu(parent=self)
-        self.menu.view.setItemDelegate(MultiSelectIndicatorMenuItemDelegate())
-        self.menu.view.setObjectName('comboListWidget')
-        self.menu.setItemHeight(33)
+        self.menu = MultiSelectComboBoxMenu(parent=self)
+        self.menu.item_toggled.connect(self.toggle_row)
 
         self.drop_down = DropDownPushButton(self)
         self.drop_down.setMenu(self.menu)
         self.__set_drop_down_width()
 
         for option in self.tr_options:
-            action = QAction(option, self)
-            action.setCheckable(True)
-            action.triggered.connect(self.check_changed)
-            self.actions.append(action)
-            self.menu.addAction(action)
+            self.menu.addAction(QAction(option, self))
 
         self.add_widget(self.drop_down, stretch=0)
         self.update_value()
@@ -63,34 +69,69 @@ class LabelAndMultiSelectionDropDown(ConfigLabelAndWidget):
         max_width = 0
         for option in self.tr_options:
             max_width = max(max_width, fm.horizontalAdvance(option))
-        self.drop_down.setMinimumWidth(max(180, max_width + 50))
+        self.drop_down.setFixedWidth(max(180, max_width + 50))
 
-    def check_changed(self, *args):
+    def toggle_row(self, row):
+        if row in self.selected_rows:
+            self.selected_rows.remove(row)
+        else:
+            self.selected_rows.add(row)
+
+        self.menu.set_selected_rows(self.selected_rows)
+        self.check_changed()
+
+    def check_changed(self):
+        if not self.user_action:
+            return
+
         options = [
-            self.tr_dict.get(action.text())
-            for action in self.actions
-            if action.isChecked()
+            self.tr_dict.get(self.tr_options[row])
+            for row in sorted(self.selected_rows)
+            if 0 <= row < len(self.tr_options)
         ]
-        if self.user_action:
-            self.update_config(options)
-            self.update_button_text()
-            self.multi_selection_changed.emit()
+        self.update_config(options)
+        self.update_button_text()
+        self.multi_selection_changed.emit()
 
     def update_value(self):
         self.user_action = False
         selected_options = self.config.get(self.key) or []
-        for action in self.actions:
-            action.setChecked(self.tr_dict[action.text()] in selected_options)
+        self.selected_rows = {
+            index
+            for index, option in enumerate(self.tr_options)
+            if self.tr_dict[option] in selected_options
+        }
+        self.menu.set_selected_rows(self.selected_rows)
         self.user_action = True
         self.update_button_text()
 
     def update_button_text(self):
         selected = [
-            action.text()
-            for action in self.actions
-            if action.isChecked()
+            self.tr_options[row]
+            for row in sorted(self.selected_rows)
+            if 0 <= row < len(self.tr_options)
         ]
         if not selected:
             self.drop_down.setText(og.app.tr("None"))
-        else:
-            self.drop_down.setText(" / ".join(selected))
+            return
+
+        self.drop_down.setText(self._compact_selected_text(selected))
+
+    def _compact_selected_text(self, selected):
+        fm = QFontMetrics(self.drop_down.font())
+        available_width = max(24, self.drop_down.width() - 34)
+        full_text = " / ".join(selected)
+        if fm.horizontalAdvance(full_text) <= available_width:
+            return full_text
+
+        if len(selected) > 2:
+            summary = f"{selected[0]} / {selected[1]} / +{len(selected) - 2}"
+            if fm.horizontalAdvance(summary) <= available_width:
+                return summary
+
+        if len(selected) > 1:
+            summary = f"{selected[0]} / +{len(selected) - 1}"
+            if fm.horizontalAdvance(summary) <= available_width:
+                return summary
+
+        return f"+{len(selected)}"


### PR DESCRIPTION
## 改动说明
- 新增独立的 `multi_selection_dropdown` 配置组件，用于下拉菜单内多选。
- 保留原有 `multi_selection` 复选框组件行为，避免影响现有配置项。
- 支持多选值作为 `sub_configs` 父配置时的可见性联动。

## 验证
- `python -m py_compile ok/gui/tasks/ConfigItemFactory.py ok/gui/tasks/ConfigCard.py ok/gui/tasks/LabelAndMultiSelection.py ok/gui/tasks/LabelAndMultiSelectionDropDown.py`
- `python -m pytest tests`：64 passed