### PR TITLE
fix(task): raise CaptureException when frame capture stalls

### DIFF
--- a/ok/task/TaskExecutor.py
+++ b/ok/task/TaskExecutor.py
@@ -23,6 +23,7 @@ class TaskExecutor:
     pause_end_time: float
     _last_frame_time: float
     wait_until_timeout: float
+    frame_stall_timeout: float
     device_manager: object
     feature_set: object
     wait_until_settle_time: float
@@ -54,7 +55,8 @@ class TaskExecutor:
                  wait_until_timeout=10, wait_until_settle_time=-1,
                  exit_event=None, feature_set=None,
                  ocr_lib=None,
-                 config_folder=None, debug=False, global_config=None, ocr_target_height=0, config=None):
+                 config_folder=None, debug=False, global_config=None, ocr_target_height=0, config=None,
+                 frame_stall_timeout=60):
         self._frame = None
         device_manager.executor = self
         self.pause_start = time.time()
@@ -73,6 +75,7 @@ class TaskExecutor:
         self.feature_set = feature_set
         self.wait_until_settle_time = wait_until_settle_time
         self.wait_scene_timeout = wait_until_timeout
+        self.frame_stall_timeout = frame_stall_timeout
         self.exit_event = exit_event
         self.debug_mode = False
         self.debug = debug
@@ -283,8 +286,16 @@ class TaskExecutor:
         if self.exit_event.is_set():
             logger.info("frame Exit event set. Exiting early.")
             sys.exit(0)
-        if self._frame is None:
+        start = time.time()
+        while self._frame is None:
             self.next_frame()
+            if self._frame is None:
+                elapsed = time.time() - start
+                if elapsed > self.frame_stall_timeout:
+                    raise CaptureException(
+                        f'Unable to capture frame for {self.frame_stall_timeout} seconds')
+                logger.warning(
+                    f'no frame for {elapsed:.0f}s, retrying capture (timeout {self.frame_stall_timeout}s)')
         return self._frame
 
     def check_enabled(self, check_pause=True):
@@ -565,7 +576,7 @@ class TaskExecutor:
                 task.info_set(QCoreApplication.tr('app', 'Error'), error)
                 logger.error(f"{name} exception stopped", e)
                 if self._frame is not None:
-                    communicate.screenshot.emit(self.frame, name, True, None)
+                    communicate.screenshot.emit(self._frame, name, True, None)
                 self.current_task = None
                 communicate.task.emit(None)
         self.destroy()

--- a/tests/test_task_executor_frame.py
+++ b/tests/test_task_executor_frame.py
@@ -1,0 +1,51 @@
+import threading
+import time
+import unittest
+
+from ok.task.TaskExecutor import TaskExecutor
+from ok.task.exceptions import CaptureException
+
+
+class TestFrameStall(unittest.TestCase):
+    def make_executor(self):
+        executor = TaskExecutor.__new__(TaskExecutor)
+        executor.exit_event = threading.Event()
+        executor.paused = False
+        executor.debug_mode = False
+        executor._frame = None
+        executor.frame_stall_timeout = 0.1
+        return executor
+
+    def test_frame_raises_capture_exception_when_capture_stalls(self):
+        executor = self.make_executor()
+
+        def stalled_next_frame(time_out=6):
+            time.sleep(0.02)
+            return None
+
+        executor.next_frame = stalled_next_frame
+        with self.assertRaises(CaptureException):
+            _ = executor.frame
+
+    def test_frame_returns_frame_when_capture_recovers(self):
+        executor = self.make_executor()
+        calls = []
+
+        def recovering_next_frame(time_out=6):
+            calls.append(1)
+            if len(calls) >= 2:
+                executor._frame = 'frame'
+            return executor._frame
+
+        executor.next_frame = recovering_next_frame
+        self.assertEqual('frame', executor.frame)
+        self.assertGreaterEqual(len(calls), 2)
+
+    def test_frame_returns_existing_frame_without_capture(self):
+        executor = self.make_executor()
+        executor._frame = 'frame'
+        self.assertEqual('frame', executor.frame)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

ok-oldking/ok-wuthering-waves#1466 — a farming task dies with `AttributeError: 'NoneType' object has no attribute 'shape'` in `FeatureSet.check_size` after the user locks the screen / turns off the monitor.

From the log attached to that issue: right before the crash the capture layer logs `no frame for 10 sec, try to restart` twice — a transient stall during the lock-screen transition. `next_frame(time_out=6)` returns `None` after its timeout, the `frame` property passes that `None` through, and the recognition path crashes. All three tracebacks in the log funnel through `FeatureSet.check_size`, so a stall of ~10-20 seconds permanently kills the running task.

## Fix

- `TaskExecutor.frame` now keeps retrying `next_frame()`, so transient capture stalls no longer kill the task — it resumes once frames come back.
- If no frame arrives for `frame_stall_timeout` seconds (new constructor param, default 60), it raises the existing `CaptureException`, which the executor main loop already handles (`capture_error` signal + task stopped with a clear message) — instead of the raw `AttributeError`.
- The error-handler screenshot path now uses the cached `_frame` instead of the `frame` property, so error handling itself can never raise `CaptureException`.

Callers that want a nullable frame still have `nullable_frame()`; no caller relies on the `frame` property returning `None` (they would all crash on it).

## Tests

`tests/test_task_executor_frame.py`, following the `TaskExecutor.__new__` pattern of `test_task_executor_queue.py`:
- capture stalled → raises `CaptureException`
- capture recovers mid-stall → returns the frame
- frame already present → returned directly, no capture call

Note: developed on Linux where the package cannot be imported (win32 deps), so the tests are written but were not executed here — verified via `py_compile` and review. Please run them on Windows before merging.
