### PR TITLE
修复开发工具和调试悬浮窗控件消失问题

### DIFF
--- a/ok/gui/start/StartTab.py
+++ b/ok/gui/start/StartTab.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QAbstractItemView, QVBoxLayout, QHBoxLayout, QWidget, QListWidgetItem, QSizePolicy
-from qfluentwidgets import FlowLayout, ListWidget, PushButton, FluentIcon, SwitchButton, SearchLineEdit
+from qfluentwidgets import ListWidget, PushButton, FluentIcon, SwitchButton, SearchLineEdit
 
 from ok.gui.Communicate import communicate
 from ok.gui.common.design_system import DesignToken
@@ -69,10 +69,9 @@ class StartTab(Tab):
         from ok import og
 
         self.debug_widget = QWidget()
-        self.debug_layout = FlowLayout(self.debug_widget, isTight=True)
+        self.debug_layout = QHBoxLayout(self.debug_widget)
         self.debug_layout.setContentsMargins(0, 0, 0, 0)
-        self.debug_layout.setHorizontalSpacing(8)
-        self.debug_layout.setVerticalSpacing(8)
+        self.debug_layout.setSpacing(8)
 
         self.export_log_button = PushButton(FluentIcon.FEEDBACK, self.tr("Export Logs"))
         self.export_log_button.clicked.connect(self.export_logs)
@@ -98,14 +97,14 @@ class StartTab(Tab):
         self.ocr_button = PushButton(FluentIcon.SEARCH, "OCR")
         self.ocr_button.clicked.connect(self.ocr_log)
         self.debug_layout.addWidget(self.ocr_button)
+        self.debug_layout.addStretch(1)
 
         self.add_card(self.tr("Debug"), self.debug_widget)
 
         self.overlay_widget = QWidget()
-        self.overlay_layout = FlowLayout(self.overlay_widget, isTight=True)
+        self.overlay_layout = QHBoxLayout(self.overlay_widget)
         self.overlay_layout.setContentsMargins(0, 0, 0, 0)
-        self.overlay_layout.setHorizontalSpacing(20)
-        self.overlay_layout.setVerticalSpacing(8)
+        self.overlay_layout.setSpacing(20)
 
         self.overlay_switch = SwitchButton()
         self.overlay_switch.setOnText(self.tr("Enable Boxes"))
@@ -120,6 +119,7 @@ class StartTab(Tab):
         self.overlay_log_switch.setChecked(og.app.ok_config.get('show_overlay_logs', True))
         self.overlay_log_switch.checkedChanged.connect(self.on_overlay_log_toggled)
         self.overlay_layout.addWidget(self.overlay_log_switch)
+        self.overlay_layout.addStretch(1)
         self.add_card(self.tr("Debug Overlay"), self.overlay_widget)
 
         self.closed_by_finish_loading = False


### PR DESCRIPTION
## 修改内容

- 将“开发工具”区域的布局由 `FlowLayout` 调整为 `QHBoxLayout`
- 将“调试悬浮窗”区域的布局由 `FlowLayout` 调整为 `QHBoxLayout`
- 恢复布局尾部的伸缩项，保持控件左对齐
- 保留原有按钮、开关、间距和事件处理逻辑

## 问题原因

这两个区域位于 `ScrollArea` 和多层 `Card` 布局中。

`FlowLayout` 的高度会随容器宽度和控件换行动态变化，但外层布局无法始终正确获取其高度。布局重新计算后，可能出现容器高度不足，导致内部控件被裁剪，表现为开发工具和调试悬浮窗下面的元素自动消失。

## 修复效果

使用高度计算更加稳定的 `QHBoxLayout` 后：

- 控件不会在布局刷新后消失
- 卡片高度可以由 Qt 布局系统稳定计算
- 控件继续保持左对齐
- 不影响原有功能和配置持久化逻辑