### PR TITLE
fix(gui): 启动任务时如果执行器处于暂停状态，则自动恢复执行

### DIFF
--- a/ok/gui/StartController.py
+++ b/ok/gui/StartController.py
@@ -61,6 +61,8 @@ class StartController(QObject):
                 if exit_after:
                     task.exit_after_task = True
                 self._mark_task_enabled(task)
+                if og.executor.paused:
+                    og.executor.start()
                 communicate.starting_emulator.emit(True, None, 0)
                 return True
         except Exception as e:


### PR DESCRIPTION
- 在 `StartController` 启用任务并准备启动模拟器时，判断 `og.executor.paused`
- 如果执行器已暂停，自动调用 `og.executor.start()` 恢复任务的执行