### PR TITLE
修复配置卡片收起后内容残留

### DIFF
--- a/ok/gui/tasks/ConfigCard.py
+++ b/ok/gui/tasks/ConfigCard.py
@@ -322,11 +322,17 @@ class ConfigCard(ConfigContentMixin, ExpandSettingCard):
         self._expand_enabled = True
         super().__init__(config_icon or FluentIcon.INFO, og.app.tr(name), og.app.tr(description))
         self._init_config_content(task, config, default_config, config_description, config_type)
+        self.expandAni.finished.connect(self._sync_collapsed_height)
 
     def setExpand(self, isExpand: bool):
         if isExpand and not self._expand_enabled:
             return
         super().setExpand(isExpand)
+
+    def _sync_collapsed_height(self):
+        """Prevent dynamic content size hints from leaving a collapsed card partially open."""
+        if not self.isExpand:
+            self.setFixedHeight(self.viewportMargins().top())
 
     def _on_empty_config_content(self):
         self._expand_enabled = False

--- a/tests/test_task_ui.py
+++ b/tests/test_task_ui.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
 
 from ok import og
@@ -19,6 +20,14 @@ class FakeConfig(dict):
 
     def has_user_config(self):
         return False
+
+
+class PopulatedFakeConfig(dict):
+    def get_default(self, key):
+        return self.get(key)
+
+    def has_user_config(self):
+        return True
 
 
 class TestTaskUi(unittest.TestCase):
@@ -67,6 +76,40 @@ class TestTaskUi(unittest.TestCase):
             card.card.titleLabel.geometry().center().y(),
             card.card.contentLabel.geometry().center().y(),
         )
+
+    def test_task_card_with_long_text_collapses_to_header_height(self):
+        values = {f"Option {index}": False for index in range(20)}
+        values["Long text"] = "A configuration value long enough to use the multiline text editor"
+        task = SimpleNamespace(
+            name="Long text task",
+            description="Collapse regression test",
+            config=PopulatedFakeConfig(values),
+            default_config=values,
+            config_description={},
+            config_type={},
+            icon=None,
+            instructions=None,
+            is_custom=False,
+            show_create_shortcut=False,
+            enabled=False,
+        )
+        card = TaskCard(task, onetime=False)
+        card.resize(1200, card.height())
+        card.show()
+        QApplication.processEvents()
+        self.addCleanup(communicate.task.disconnect, card.update_buttons)
+        self.addCleanup(card.close)
+
+        header_height = card.viewportMargins().top()
+        card.setExpand(True)
+        QTest.qWait(300)
+        QApplication.processEvents()
+        self.assertGreater(card.height(), header_height)
+
+        card.setExpand(False)
+        QTest.qWait(300)
+        QApplication.processEvents()
+        self.assertEqual(header_height, card.height())
 
     def test_status_panel_stays_closed_until_a_different_task_starts(self):
         first_task = SimpleNamespace(


### PR DESCRIPTION
## 问题

配置卡片包含多行文本等动态高度控件时，收起动画结束后可能仍残留部分内容区域。

原因是动画执行期间滚动范围发生变化，动画开始时计算的目标高度失效。

## 修复

收起动画完成后，将卡片高度同步为当前标题栏高度。

## 测试

- 新增长文本配置回归测试
- 修复前：期望高度 50，实际高度 108
- 修复后：完整测试集共 112 项，全部通过