### PR TITLE
fix: align launcher auto-start reset default

### DIFF
--- a/ok/util/GlobalConfig.py
+++ b/ok/util/GlobalConfig.py
@@ -146,7 +146,7 @@ class AppLauncherConfig(dict):
         self.pyappify_module = pyappify_module
         self.basic_config = basic_config
         self.default = {
-            APP_LAUNCHER_AUTO_START: False,
+            APP_LAUNCHER_AUTO_START: True,
             APP_LAUNCHER_UPDATE_METHOD: UPDATE_METHOD_VALUES['AUTO_UPDATE'],
         }
         super().__init__(self._to_display_config(launcher_config))

--- a/tests/test_global_config.py
+++ b/tests/test_global_config.py
@@ -227,10 +227,10 @@ class TestBasicOptions(unittest.TestCase):
             config.reset_to_default()
 
             self.assertEqual(
-                {'auto_start': False, 'update_method': 'AUTO_UPDATE'},
+                {'auto_start': True, 'update_method': 'AUTO_UPDATE'},
                 updates[-1],
             )
-            self.assertFalse(config[APP_LAUNCHER_AUTO_START])
+            self.assertTrue(config[APP_LAUNCHER_AUTO_START])
             self.assertEqual('Automatic Update(Release Only)', config[APP_LAUNCHER_UPDATE_METHOD])
             self.assertFalse(basic_config[KILL_LAUNCHER_AFTER_START])
 


### PR DESCRIPTION
## Summary

- Reset launcher auto-start to `true`, matching the legacy launcher behavior and the PyAppify default proposed in ok-oldking/pyappify#7.
- Preserve the current launcher configuration until the user explicitly resets it.
- Update the existing reset behavior test.

## Testing

- `python -m pytest tests/test_global_config.py -q` (`11 passed`)
- `git diff --check`