### PR TITLE
refactor(gui): 使用 ExpandLayout 重构任务卡片展开布局

### DIFF
--- a/ok/gui/tasks/ConfigCard.py
+++ b/ok/gui/tasks/ConfigCard.py
@@ -1,5 +1,5 @@
 from PySide6.QtCore import Qt
-from PySide6.QtWidgets import QApplication, QFrame, QHBoxLayout
+from PySide6.QtWidgets import QFrame, QHBoxLayout
 from qfluentwidgets import FluentIcon, ExpandSettingCard, PushButton
 
 from ok import og
@@ -341,37 +341,10 @@ class ConfigCard(ConfigContentMixin, ExpandSettingCard):
         self._init_config_content(task, config, default_config, config_description, config_type)
 
     def setExpand(self, isExpand: bool):
+        """Keep empty cards collapsed while retaining the native animation."""
         if isExpand and not self._expand_enabled:
             return
-        if self.isExpand == isExpand:
-            return
-
-        content_height = self.viewLayout.sizeHint().height()
-        header_height = self.viewportMargins().top()
-        target_height = header_height + content_height if isExpand else header_height
-        parent = self.parentWidget()
-        parent_updates_enabled = parent is not None and parent.updatesEnabled()
-        if parent_updates_enabled:
-            parent.setUpdatesEnabled(False)
-
-        self.expandAni.stop()
-        try:
-            self.spaceWidget.setFixedHeight(content_height)
-            self.verticalScrollBar().setValue(0)
-            self.isExpand = isExpand
-            self.setProperty('isExpand', isExpand)
-            self.setStyle(QApplication.style())
-            self.card.expandButton.setExpand(isExpand)
-            self.setFixedHeight(target_height)
-
-            parent_layout = parent.layout() if parent is not None else None
-            if parent_layout is not None:
-                parent_layout.invalidate()
-                parent_layout.activate()
-        finally:
-            if parent_updates_enabled:
-                parent.setUpdatesEnabled(True)
-                parent.update()
+        super().setExpand(isExpand)
 
     def _on_empty_config_content(self):
         self._expand_enabled = False

--- a/ok/gui/tasks/LabelAndTextEdit.py
+++ b/ok/gui/tasks/LabelAndTextEdit.py
@@ -21,6 +21,9 @@ class LabelAndTextEdit(ConfigLabelAndWidget):
         self.update_value()
         self.text_edit.textChanged.connect(self.value_changed)
         self.add_widget(self.text_edit, stretch=0)
+        # The editor is six lines high, so this row must not be compressed to
+        # LabelAndWidget's generic one-line minimum inside an ExpandSettingCard.
+        self.setMinimumHeight(self.sizeHint().height())
 
     def update_value(self):
         value = self.config.get(self.key)

--- a/ok/gui/tasks/OneTimeTaskTab.py
+++ b/ok/gui/tasks/OneTimeTaskTab.py
@@ -22,10 +22,11 @@ class OneTimeTaskTab(TaskTab):
                 break
                 
         if self.imported_file_name:
-            from PySide6.QtWidgets import QHBoxLayout, QSpacerItem, QSizePolicy
+            from PySide6.QtWidgets import QHBoxLayout, QSpacerItem, QSizePolicy, QWidget
             from qfluentwidgets import PushButton, FluentIcon
             
-            self.btn_layout = QHBoxLayout()
+            self.button_container = QWidget()
+            self.btn_layout = QHBoxLayout(self.button_container)
             self.btn_layout.setContentsMargins(0, 10, 0, 0)
             self.btn_layout.addItem(QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum))
             
@@ -33,8 +34,8 @@ class OneTimeTaskTab(TaskTab):
             self.delete_btn.clicked.connect(self.delete_script)
             self.btn_layout.addWidget(self.delete_btn)
             
-            # Position it at the end of vBoxLayout
-            self.vBoxLayout.addLayout(self.btn_layout)
+            # Keep this footer below the expandable task cards.
+            self.taskCardLayout.addWidget(self.button_container)
             
         from ok.gui.Communicate import communicate
         communicate.task_list_updated.connect(self.refresh_ui)
@@ -51,13 +52,9 @@ class OneTimeTaskTab(TaskTab):
     def refresh_ui(self):
         # Remove old cards
         for w in self.card_widgets:
-            self.removeWidget(w)
+            self.remove_task_card(w)
             w.deleteLater()
         self.card_widgets.clear()
-        
-        # If we have a delete button, it's at the end. We need to keep it there.
-        if hasattr(self, 'btn_layout'):
-            self.vBoxLayout.removeItem(self.btn_layout)
         
         self.tasks = []
         for task in og.executor.onetime_tasks:
@@ -72,10 +69,7 @@ class OneTimeTaskTab(TaskTab):
         for task in self.tasks:
             task_card = TaskCard(task, True)
             self.card_widgets.append(task_card)
-            self.vBoxLayout.addWidget(task_card) # Use vBoxLayout directly to avoid stretch issues
-            
-        if hasattr(self, 'btn_layout'):
-            self.vBoxLayout.addLayout(self.btn_layout)
+            self.add_task_card(task_card)
 
     def in_current_list(self, task):
         return getattr(self, 'tasks', None) and task in self.tasks

--- a/ok/gui/tasks/TaskTab.py
+++ b/ok/gui/tasks/TaskTab.py
@@ -1,4 +1,5 @@
 import time
+from typing import cast
 
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import QTableWidgetItem
@@ -6,6 +7,7 @@ from qfluentwidgets import FluentIcon, ToolButton
 
 from ok import Logger, og
 from ok.gui.tasks.TooltipTableWidget import TooltipTableWidget
+from ok.gui.widget.ExpandCardLayout import ExpandCardLayout
 from ok.gui.widget.Tab import Tab
 from ok.gui.widget.UpdateConfigWidgetItem import value_to_string
 
@@ -13,8 +15,12 @@ logger = Logger.get_logger(__name__)
 
 
 class TaskTab(Tab):
+    taskCardLayout: ExpandCardLayout
+
     def __init__(self):
-        super().__init__()
+        # Match the official settings-page construction: ExpandLayout owns the
+        # scroll widget directly, so it is the sole owner of card heights.
+        super().__init__(layout_class=ExpandCardLayout)
         self.keep_info_when_done = False
         self.current_task_name = ""
         self.last_task = None
@@ -28,7 +34,8 @@ class TaskTab(Tab):
         self.close_info_button.setToolTip(self.tr("Close"))
         self.close_info_button.clicked.connect(self.close_task_info)
         self.task_info_container.add_top_widget(self.close_info_button)
-        self.add_widget(self.task_info_container)
+
+        self.taskCardLayout = cast(ExpandCardLayout, self.vBoxLayout)
 
         self.task_info_labels = [self.tr('Info'), self.tr('Value')]
         self.task_info_table.setColumnCount(len(self.task_info_labels))  # Name and Value
@@ -50,6 +57,12 @@ class TaskTab(Tab):
 
     def in_current_list(self, task):
         return True
+
+    def add_task_card(self, card):
+        self.taskCardLayout.addWidget(card)
+
+    def remove_task_card(self, card):
+        self.taskCardLayout.removeWidget(card)
 
     @staticmethod
     def time_elapsed(start_time):

--- a/ok/gui/tasks/TriggerTaskTab.py
+++ b/ok/gui/tasks/TriggerTaskTab.py
@@ -16,7 +16,7 @@ class TriggerTaskTab(TaskTab):
 
     def refresh_ui(self):
         for w in self.card_widgets:
-            self.removeWidget(w)
+            self.remove_task_card(w)
             w.deleteLater()
         self.card_widgets.clear()
         
@@ -25,7 +25,7 @@ class TriggerTaskTab(TaskTab):
                 continue
             task_card = TaskCard(task, False)
             self.card_widgets.append(task_card)
-            self.add_widget(task_card)
+            self.add_task_card(task_card)
 
     def in_current_list(self, task):
         return task in og.executor.trigger_tasks and getattr(task, 'visible', True)

--- a/ok/gui/widget/ExpandCardLayout.py
+++ b/ok/gui/widget/ExpandCardLayout.py
@@ -1,0 +1,25 @@
+from PySide6.QtWidgets import QWidgetItem
+from qfluentwidgets import ExpandLayout
+
+
+class ExpandCardLayout(ExpandLayout):
+    """Project adapter around the official ``qfluentwidgets.ExpandLayout``.
+
+    The official layout is retained for its expand-animation behaviour.  The
+    adapter gives direct children the correct parent while retaining the
+    standard ``QLayout`` item lifecycle used by dynamically refreshed lists.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def addWidget(self, widget, stretch=0, alignment=None):
+        if self.indexOf(widget) >= 0:
+            return
+
+        parent = self.parentWidget()
+        if parent is not None and widget.parentWidget() is not parent:
+            widget.setParent(parent)
+
+        super().addWidget(widget)
+        self.addItem(QWidgetItem(widget))

--- a/ok/gui/widget/Tab.py
+++ b/ok/gui/widget/Tab.py
@@ -11,12 +11,12 @@ from ok.gui.widget.StartLoadingDialog import StartLoadingDialog
 
 
 class Tab(ScrollArea):
-    def __init__(self):
+    def __init__(self, layout_class=QVBoxLayout):
         super().__init__()
         self.loading_dialog = None
         self.view = QWidget(self)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.vBoxLayout = QVBoxLayout(self.view)
+        self.vBoxLayout = layout_class(self.view)
 
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setViewportMargins(0, 0, 0, 0)

--- a/tests/test_expand_card_layout.py
+++ b/tests/test_expand_card_layout.py
@@ -1,0 +1,59 @@
+import os
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QLabel, QWidget
+from qfluentwidgets import ExpandLayout, ExpandSettingCard, FluentIcon
+
+from ok.gui.widget.ExpandCardLayout import ExpandCardLayout
+
+
+class TestExpandCardLayout(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.qt_app = QApplication.instance() or QApplication([])
+
+    def test_expanding_card_is_a_direct_child_of_the_official_layout(self):
+        host = QWidget()
+        layout = ExpandCardLayout(host)
+        card = ExpandSettingCard(FluentIcon.INFO, "Card")
+        card.viewLayout.addWidget(QLabel("Animated content"))
+
+        layout.addWidget(card)
+        host.resize(600, 400)
+        host.show()
+        QApplication.processEvents()
+        self.addCleanup(host.close)
+
+        self.assertIsInstance(layout, ExpandLayout)
+        self.assertIs(card.parentWidget(), host)
+
+        collapsed_height = card.height()
+        card.setExpand(True)
+        QTest.qWait(300)
+        self.assertGreater(card.height(), collapsed_height)
+
+        layout.removeWidget(card)
+        self.assertEqual(0, layout.count())
+
+    def test_cards_can_be_removed(self):
+        host = QWidget()
+        layout = ExpandCardLayout(host)
+        first = QLabel("First")
+        second = QLabel("Second")
+
+        layout.addWidget(first)
+        layout.addWidget(second)
+        self.assertEqual(2, layout.count())
+        self.assertIs(first, layout.itemAt(0).widget())
+        self.assertIs(second, layout.itemAt(1).widget())
+
+        layout.removeWidget(second)
+        self.assertEqual(1, layout.count())
+        self.assertIs(first, layout.itemAt(0).widget())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_task_ui.py
+++ b/tests/test_task_ui.py
@@ -7,11 +7,13 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication
+from qfluentwidgets import ExpandLayout
 
 from ok import og
 from ok.gui.Communicate import communicate
 from ok.gui.tasks.TaskCard import TaskCard
 from ok.gui.tasks.TaskTab import TaskTab
+from ok.gui.widget.ExpandCardLayout import ExpandCardLayout
 
 
 class FakeConfig(dict):
@@ -77,9 +79,15 @@ class TestTaskUi(unittest.TestCase):
             card.card.contentLabel.geometry().center().y(),
         )
 
-    def test_task_card_with_long_text_collapses_to_header_height(self):
-        values = {f"Option {index}": False for index in range(20)}
-        values["Long text"] = "A configuration value long enough to use the multiline text editor"
+    def test_task_cards_use_a_nested_expand_layout(self):
+        tab = TaskTab()
+        self.addCleanup(tab.close)
+
+        self.assertIsInstance(tab.taskCardLayout, ExpandLayout)
+        self.assertIs(tab.taskCardLayout, tab.view.layout())
+
+    def test_task_card_uses_native_expansion_state(self):
+        values = {"Long text": "A configuration value long enough to use the multiline text editor"}
         task = SimpleNamespace(
             name="Long text task",
             description="Collapse regression test",
@@ -94,21 +102,25 @@ class TestTaskUi(unittest.TestCase):
             enabled=False,
         )
         card = TaskCard(task, onetime=False)
-        card.resize(1200, card.height())
-        card.show()
+        tab = TaskTab()
+        tab.add_task_card(card)
+        tab.resize(1200, 800)
+        tab.show()
         QApplication.processEvents()
+        self.addCleanup(tab.close)
         self.addCleanup(communicate.task.disconnect, card.update_buttons)
-        self.addCleanup(card.close)
 
         header_height = card.viewportMargins().top()
+
         card.setExpand(True)
         QTest.qWait(300)
         QApplication.processEvents()
-        self.assertGreater(card.height(), header_height)
+        self.assertTrue(card.isExpand)
 
         card.setExpand(False)
         QTest.qWait(300)
         QApplication.processEvents()
+        self.assertFalse(card.isExpand)
         self.assertEqual(header_height, card.height())
 
     def test_status_panel_stays_closed_until_a_different_task_starts(self):


### PR DESCRIPTION
- 引入 `ExpandCardLayout` 适配器，以支持任务卡片的动态添加与移除
- 移除 `ConfigCard` 中的自定义高度计算，恢复原生 `ExpandSettingCard` 展开逻辑与动画
- 为 `LabelAndTextEdit` 设置最小高度，防止多行文本编辑框在展开时被过度压缩
- 更新 `TaskTab` 及其子类，统一使用 `ExpandCardLayout` 接口管理卡片布局
- 新增及更新相关 UI 单元测试