### PR TITLE
refactor(gui): 重构任务页布局结构与配置组件拉伸逻辑

### DIFF
--- a/ok/gui/tasks/ConfigCard.py
+++ b/ok/gui/tasks/ConfigCard.py
@@ -299,56 +299,10 @@ class ConfigCard(ConfigContentMixin, ExpandSettingCard):
         self._init_config_content(task, config, default_config, config_description, config_type)
 
     def setExpand(self, isExpand: bool):
+        """Keep empty cards collapsed while retaining the native animation."""
         if isExpand and not self._expand_enabled:
             return
-        if self.isExpand == isExpand:
-            return
-
-        content_height = self._visible_content_height()
-        header_height = self.viewportMargins().top()
-        target_height = header_height + content_height if isExpand else header_height
-        parent = self.parentWidget()
-        parent_updates_enabled = parent is not None and parent.updatesEnabled()
-        if parent_updates_enabled:
-            parent.setUpdatesEnabled(False)
-
-        self.expandAni.stop()
-        try:
-            self.spaceWidget.hide()
-            self.verticalScrollBar().setValue(0)
-            self.isExpand = isExpand
-            self.setProperty('isExpand', isExpand)
-            self.setStyle(QApplication.style())
-            self.card.expandButton.setExpand(isExpand)
-            self.setFixedHeight(target_height)
-
-            parent_layout = parent.layout() if parent is not None else None
-            if parent_layout is not None:
-                parent_layout.invalidate()
-                parent_layout.activate()
-        finally:
-            if parent_updates_enabled:
-                parent.setUpdatesEnabled(True)
-                parent.update()
-
-    def _adjustViewSize(self):
-        """Resize to visible rows only; hidden sub-configs must not reserve space."""
-        self.spaceWidget.hide()
-        if self.isExpand:
-            self.setFixedHeight(self.card.height() + self._visible_content_height())
-
-    def _visible_content_height(self):
-        margins = self.viewLayout.contentsMargins()
-        self.viewLayout.activate()
-        bottom = margins.top()
-        for index in range(self.viewLayout.count()):
-            item = self.viewLayout.itemAt(index)
-            widget = item.widget()
-            if widget is not None and widget.isHidden():
-                continue
-
-            bottom = max(bottom, item.geometry().bottom() + 1)
-        return bottom + margins.bottom()
+        super().setExpand(isExpand)
 
     def _on_empty_config_content(self):
         self._expand_enabled = False

--- a/ok/gui/tasks/LabelAndWidget.py
+++ b/ok/gui/tasks/LabelAndWidget.py
@@ -16,7 +16,8 @@ class LabelAndWidget(QWidget):
         self.title_layout.setSpacing(2)
         # The description column owns the flexible row width. Controls remain
         # right-aligned at their requested size without forcing early wrapping.
-        self.layout.addLayout(self.title_layout, stretch=1)
+        self.layout.addLayout(self.title_layout)
+        self.layout.addStretch(1)
         translated_title = og.app.tr(title)
         if '{app_name}' in translated_title:
             translated_title = translated_title.format(app_name=(og.config or {}).get('gui_title', ''))
@@ -28,6 +29,7 @@ class LabelAndWidget(QWidget):
         if content:
             self.contentLabel = QLabel(og.app.tr(content))
             self.contentLabel.setObjectName('contentLabel')
+            self.contentLabel.setMinimumWidth(220)
             self.contentLabel.setWordWrap(True)
             self.title_layout.addWidget(self.contentLabel)
         self.title_layout.setAlignment(Qt.AlignVCenter)

--- a/ok/gui/tasks/OneTimeTaskTab.py
+++ b/ok/gui/tasks/OneTimeTaskTab.py
@@ -34,8 +34,8 @@ class OneTimeTaskTab(TaskTab):
             self.delete_btn.clicked.connect(self.delete_script)
             self.btn_layout.addWidget(self.delete_btn)
             
-            # Keep this footer below the expandable task cards.
-            self.taskCardLayout.addWidget(self.button_container)
+            # Keep this ordinary footer outside the expandable-card layout.
+            self.vBoxLayout.addWidget(self.button_container)
             
         from ok.gui.Communicate import communicate
         communicate.task_list_updated.connect(self.refresh_ui)

--- a/ok/gui/tasks/TaskCard.py
+++ b/ok/gui/tasks/TaskCard.py
@@ -90,7 +90,7 @@ class TaskCard(ConfigCard):
         self.header_text_layout.addWidget(self.card.contentLabel, 1, Qt.AlignVCenter)
         self.card.vBoxLayout.addLayout(self.header_text_layout)
 
-        compact_height = 56
+        compact_height = 50
         self.card.setFixedHeight(compact_height)
         self.setViewportMargins(0, compact_height, 0, 0)
         self.setFixedHeight(compact_height)

--- a/ok/gui/tasks/TaskTab.py
+++ b/ok/gui/tasks/TaskTab.py
@@ -1,8 +1,7 @@
 import time
-from typing import cast
 
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtWidgets import QTableWidgetItem
+from PySide6.QtWidgets import QTableWidgetItem, QWidget
 from qfluentwidgets import FluentIcon, ToolButton
 
 from ok import Logger, og
@@ -15,12 +14,8 @@ logger = Logger.get_logger(__name__)
 
 
 class TaskTab(Tab):
-    taskCardLayout: ExpandCardLayout
-
     def __init__(self):
-        # Match the official settings-page construction: ExpandLayout owns the
-        # scroll widget directly, so it is the sole owner of card heights.
-        super().__init__(layout_class=ExpandCardLayout)
+        super().__init__()
         self.keep_info_when_done = False
         self.current_task_name = ""
         self.last_task = None
@@ -35,7 +30,11 @@ class TaskTab(Tab):
         self.close_info_button.clicked.connect(self.close_task_info)
         self.task_info_container.add_top_widget(self.close_info_button)
 
-        self.taskCardLayout = cast(ExpandCardLayout, self.vBoxLayout)
+        # The official layout owns only expandable cards. Ordinary status and
+        # action widgets stay in the page's regular QVBoxLayout.
+        self.task_cards_view = QWidget(self.view)
+        self.taskCardLayout = ExpandCardLayout(self.task_cards_view)
+        self.vBoxLayout.addWidget(self.task_cards_view)
 
         self.task_info_labels = [self.tr('Info'), self.tr('Value')]
         self.task_info_table.setColumnCount(len(self.task_info_labels))  # Name and Value

--- a/ok/gui/widget/Tab.py
+++ b/ok/gui/widget/Tab.py
@@ -11,12 +11,12 @@ from ok.gui.widget.StartLoadingDialog import StartLoadingDialog
 
 
 class Tab(ScrollArea):
-    def __init__(self, layout_class=QVBoxLayout):
+    def __init__(self):
         super().__init__()
         self.loading_dialog = None
         self.view = QWidget(self)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-        self.vBoxLayout = layout_class(self.view)
+        self.vBoxLayout = QVBoxLayout(self.view)
 
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setViewportMargins(0, 0, 0, 0)

--- a/tests/test_task_ui.py
+++ b/tests/test_task_ui.py
@@ -82,8 +82,8 @@ class TestTaskUi(unittest.TestCase):
         self.addCleanup(communicate.task.disconnect, card.update_buttons)
         self.addCleanup(card.close)
 
-        self.assertEqual(56, card.card.height())
-        self.assertEqual(56, card.height())
+        self.assertEqual(50, card.card.height())
+        self.assertEqual(50, card.height())
         self.assertTrue(card.card.iconLabel.isHidden())
         self.assertIs(card.card.vBoxLayout, card.card.hBoxLayout.itemAt(1).layout())
         self.assertEqual(1, card.card.vBoxLayout.count())

--- a/tests/test_task_ui.py
+++ b/tests/test_task_ui.py
@@ -48,7 +48,7 @@ class TestTaskUi(unittest.TestCase):
         og.app = self.original_app
         og.executor = self.original_executor
 
-    def test_config_description_column_uses_available_row_width(self):
+    def test_config_row_uses_a_spacer_for_extra_width(self):
         row = LabelAndWidget(
             'Local Client Notification',
             'Send notifications through local QQ or WeChat clients')
@@ -57,9 +57,11 @@ class TestTaskUi(unittest.TestCase):
         QApplication.processEvents()
         self.addCleanup(row.close)
 
-        self.assertEqual(1, row.layout.stretch(0))
-        self.assertEqual(1, row.layout.count())
-        self.assertGreater(row.title_layout.geometry().width(), 400)
+        self.assertEqual(0, row.layout.stretch(0))
+        self.assertEqual(2, row.layout.count())
+        self.assertEqual(1, row.layout.stretch(1))
+        self.assertIsNotNone(row.layout.itemAt(1).spacerItem())
+        self.assertGreater(row.layout.itemAt(1).spacerItem().geometry().width(), 0)
 
     def test_task_card_uses_single_line_compact_header(self):
         task = SimpleNamespace(
@@ -98,7 +100,8 @@ class TestTaskUi(unittest.TestCase):
         self.addCleanup(tab.close)
 
         self.assertIsInstance(tab.taskCardLayout, ExpandLayout)
-        self.assertIs(tab.taskCardLayout, tab.view.layout())
+        self.assertIs(tab.taskCardLayout, tab.task_cards_view.layout())
+        self.assertIsNot(tab.taskCardLayout, tab.view.layout())
 
     def test_task_card_uses_native_expansion_state(self):
         values = {"Long text": "A configuration value long enough to use the multiline text editor"}


### PR DESCRIPTION
- 将 ExpandCardLayout 仅应用于独立的任务卡片视图，避免非卡片部件受到布局约束影响
- 将 OneTimeTaskTab 的底部按钮容器移出任务卡片布局，直接加入主 QVBoxLayout
- 移除 Tab 基类的 layout_class 参数，恢复默认使用 QVBoxLayout
- 优化 LabelAndWidget 布局拉伸机制，添加 Spacer 并设置描述文本最小宽度
- 更新对应的 UI 布局单元测试