### PR TITLE
修复 GUI 卡死（线程风暴）与新增可点击悬浮窗

### DIFF
--- a/ok/__init__.py
+++ b/ok/__init__.py
@@ -460,9 +460,50 @@ class App(_OverlayConfigMixin):
 
         self.timer = QTimer()
         self.timer.start(1000)
-        self.timer.timeout.connect(lambda: None)
+        self.timer.timeout.connect(self._gui_heartbeat)
+
+        # Watchdog: if the Qt (GUI) thread stops processing events the window
+        # becomes "not responding" and the whole Python process appears stuck.
+        # Dump every thread's stack to logs/thread_dumps.txt so the hang can be
+        # diagnosed, and finally exit so a relaunch is not blocked by the
+        # stuck process holding the single-instance mutex.
+        self._last_gui_heartbeat = time.monotonic()
+        self._watchdog_stop = threading.Event()
+        self._watchdog_thread = threading.Thread(target=self._watchdog_loop,
+                                                 name='GuiWatchdog', daemon=True)
+        self._watchdog_thread.start()
 
         sys.exit(self.app.exec())
+
+    def _gui_heartbeat(self):
+        """Called every second by the Qt event loop; proves the GUI thread is alive."""
+        self._last_gui_heartbeat = time.monotonic()
+
+    def _watchdog_loop(self):
+        stuck_since = None
+        while not self._watchdog_stop.wait(2):
+            stuck_for = time.monotonic() - self._last_gui_heartbeat
+            if stuck_for > 8:
+                if stuck_since is None:
+                    stuck_since = time.monotonic()
+                    logger.error(
+                        f'GUI thread unresponsive for {stuck_for:.0f}s; dumping thread stacks for diagnosis.')
+                    try:
+                        from ok.capture.windows.dump import dump_threads
+                        dump_threads()
+                    except Exception as e:
+                        logger.error(f'Failed to dump threads: {e}')
+                elif time.monotonic() - stuck_since > 120:
+                    logger.error(
+                        f'GUI thread still unresponsive after 120s; exiting to release the instance mutex.')
+                    try:
+                        from ok.capture.windows.dump import dump_threads
+                        dump_threads()
+                    except Exception:
+                        pass
+                    os._exit(1)
+            else:
+                stuck_since = None
 
 
 class HeadlessApp(_OverlayConfigMixin):

--- a/ok/capture/windows/dump.py
+++ b/ok/capture/windows/dump.py
@@ -3,7 +3,14 @@ import sys
 import threading
 import traceback
 
-from ok.util.file import get_relative_path
+# dump.py lives at <app>/ok/capture/windows/, so the app working directory is
+# three levels up.  Resolve it from __file__ rather than os.getcwd() because a
+# hung process may have an invalid/deleted working directory (which made the
+# old dump path fail with OSError 22 "Invalid argument").
+APP_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                       os.pardir, os.pardir, os.pardir))
+LOG_DIR = os.path.join(APP_DIR, 'logs')
+FALLBACK_DIR = os.path.join(os.path.expanduser('~'), 'Documents')
 
 
 def get_thread_name(thread_id):
@@ -13,18 +20,45 @@ def get_thread_name(thread_id):
     return ""  # Return empty string if the thread name is not found
 
 
-def dump_threads():
-    # Get the stack trace for each thread
+def dump_threads(output_file=None):
+    """Dump every thread's Python stack to a text file.
+
+    Returns the path written, or None if it could not be written anywhere.
+    """
     thread_dumps = []
     for thread_id, frame in sys._current_frames().items():
         thread_name = get_thread_name(thread_id)
         thread_dump = f"Stack for thread {thread_id} (Name: {thread_name}):\n"
-        thread_dump += "".join(traceback.format_stack(frame))
+        try:
+            thread_dump += "".join(traceback.format_stack(frame))
+        except Exception:
+            pass
         thread_dumps.append(thread_dump)
 
-    # Write the thread dumps to a file
-    output_file = get_relative_path(os.path.join('logs', "thread_dumps.txt"))
-    print(f'Dumping threads to {output_file}')
+    body = "\n\n".join(thread_dumps)
 
-    with open(output_file, "w", encoding='utf-8') as f:
-        f.write("\n\n".join(thread_dumps))
+    candidates = []
+    if output_file:
+        candidates.append(output_file)
+    candidates.append(os.path.join(LOG_DIR, "thread_dumps.txt"))
+    candidates.append(os.path.join(FALLBACK_DIR, "ok-ww_thread_dumps.txt"))
+
+    last_error = None
+    for candidate in candidates:
+        try:
+            directory = os.path.dirname(candidate)
+            if directory:
+                os.makedirs(directory, exist_ok=True)
+            with open(candidate, "w", encoding='utf-8') as f:
+                f.write(body)
+            return candidate
+        except Exception as e:  # noqa: BLE001 - fall through to next candidate
+            last_error = e
+
+    # pythonw has no stdout; print() can raise if sys.stdout is None.
+    try:
+        print(f'Dumping threads failed ({last_error}); writing to stderr')
+        sys.stderr.write(body)
+    except Exception:
+        pass
+    return None

--- a/ok/ui/overlay/win32_gdi.py
+++ b/ok/ui/overlay/win32_gdi.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ctypes
 import os
+import heapq
 import threading
 import time
 from ctypes import wintypes
@@ -234,6 +235,19 @@ class Win32GdiOverlay:
         self.blur_images = []
         self._py_object = ctypes.py_object(self) if self._native_available else None
 
+        # A single scheduler thread for expiring boxes/custom painters.  The
+        # previous implementation created one threading.Timer per draw_box
+        # event, which floods the process with hundreds of short-lived threads
+        # during combat and stalls the GUI thread inside timer.start().
+        self._expiry_heap = []
+        self._expiry_counter = 0
+        self._expiry_condition = threading.Condition()
+        self._expiry_stop = False
+        self._expiry_thread = threading.Thread(target=self._expiry_loop,
+                                               name="Win32GdiOverlayExpiry",
+                                               daemon=True)
+        self._expiry_thread.start()
+
         communicate.draw_box.connect(self.on_draw_box)
         communicate.clear_box.connect(self.clear_drawing)
         communicate.blur_overlay.connect(self.update_blur_patches)
@@ -434,11 +448,45 @@ class Win32GdiOverlay:
         if self._native_available and self._hwnd:
             user32.PostMessageW(self._hwnd, WM_CLOSE, 0, 0)
             self._thread.join(timeout=1)
+        with self._expiry_condition:
+            self._expiry_stop = True
+            self._expiry_condition.notify_all()
 
     def _schedule_expiry(self, duration, callback):
-        timer = threading.Timer(max(0, float(duration)) + .01, callback)
-        timer.daemon = True
-        timer.start()
+        """Schedule ``callback`` once after ``duration`` seconds.
+
+        Uses one shared background thread instead of spawning a new
+        ``threading.Timer`` thread per event.
+        """
+        with self._expiry_condition:
+            if self._expiry_stop:
+                return
+            heapq.heappush(
+                self._expiry_heap,
+                (time.monotonic() + max(0, float(duration)) + 0.01,
+                 self._expiry_counter, callback),
+            )
+            self._expiry_counter += 1
+            self._expiry_condition.notify()
+
+    def _expiry_loop(self):
+        """Run due overlay expiry callbacks on one long-lived thread."""
+        while True:
+            with self._expiry_condition:
+                while not self._expiry_heap and not self._expiry_stop:
+                    self._expiry_condition.wait()
+                if self._expiry_stop and not self._expiry_heap:
+                    return
+                expire_at, _, callback = self._expiry_heap[0]
+                now = time.monotonic()
+                if expire_at > now:
+                    self._expiry_condition.wait(expire_at - now)
+                    continue
+                heapq.heappop(self._expiry_heap)
+            try:
+                callback()
+            except Exception as e:
+                logger.warning(f'overlay expiry callback failed: {e}')
 
     def _schedule_render(self):
         if not self._native_available or not self._hwnd or self._closed:

--- a/ok/ui/qt/MainWindow.py
+++ b/ok/ui/qt/MainWindow.py
@@ -27,6 +27,7 @@ def _patched_message_box_base_keyPressEvent(self, e):
 MessageBoxBase.keyPressEvent = _patched_message_box_base_keyPressEvent
 
 
+from ok import og
 from ok.util.config import Config
 
 from ok.ui.qt.Communicate import communicate
@@ -78,6 +79,9 @@ class MainWindow(FluentWindow):
         self.ok_config = ok_config
         self.basic_global_config = global_config.get_config(basic_options)
         self.main_window_config = Config('main_window', {'last_version': 'v0.0.0'})
+        self.floating_window_config = Config('floating_window', {'enabled': False, 'x': -1, 'y': -1})
+        self.floating_window = None
+        self.floating_switch_card = None
         self.exit_event = exit_event
         from ok.ui.qt.start.StartTab import StartTab
         self.start_tab = StartTab(config, exit_event)
@@ -210,6 +214,7 @@ class MainWindow(FluentWindow):
 
         from ok.ui.qt.settings.SettingTab import SettingTab
         self.setting_tab = SettingTab()
+        self.floating_switch_card = getattr(self.setting_tab, 'floating_window_card', None)
         self.addSubInterface(self.setting_tab, FluentIcon.SETTING, self.tr('Settings'),
                              position=NavigationItemPosition.BOTTOM)
 
@@ -232,6 +237,10 @@ class MainWindow(FluentWindow):
         menu = QMenu()
         exit_action = menu.addAction(self.tr("Exit"))
         exit_action.triggered.connect(self.tray_quit)
+        self.floating_tray_action = menu.addAction(og.app.tr("Floating Window"))
+        self.floating_tray_action.setCheckable(True)
+        self.floating_tray_action.setChecked(self.floating_window_config.get('enabled', False))
+        self.floating_tray_action.triggered.connect(self.set_floating_window_enabled)
 
         self.tray = QSystemTrayIcon(icon, parent=self)
 
@@ -396,17 +405,24 @@ class MainWindow(FluentWindow):
             import ctypes
             from ctypes import wintypes
 
-            native_message = wintypes.MSG.from_address(int(message))
-            if native_message.message == 0x0320:  # WM_DWMCOLORIZATIONCOLORCHANGED
+            # Reading the whole MSG plus scanning lParam strings on every native
+            # message is wasteful: this window receives one native event per
+            # mouse move/click.  Peek at just the message id first (the second
+            # field of the MSG struct) and only parse further for the two
+            # messages we actually care about.
+            message_id = ctypes.c_uint.from_address(
+                int(message) + ctypes.sizeof(wintypes.HWND)).value
+            if message_id == 0x0320:  # WM_DWMCOLORIZATIONCOLORCHANGED
                 logger.info('System colorization colors changed')
                 self._schedule_system_theme_change()
-            elif (
-                native_message.message == 0x001A  # WM_SETTINGCHANGE
-                and native_message.lParam
-                and ctypes.wstring_at(native_message.lParam) == "ImmersiveColorSet"
-            ):
-                logger.info('System theme changed')
-                self._schedule_system_theme_change()
+            elif message_id == 0x001A:  # WM_SETTINGCHANGE
+                native_message = wintypes.MSG.from_address(int(message))
+                if (
+                    native_message.lParam
+                    and ctypes.wstring_at(native_message.lParam) == "ImmersiveColorSet"
+                ):
+                    logger.info('System theme changed')
+                    self._schedule_system_theme_change()
         except (OSError, TypeError, ValueError) as e:
             logger.error('Failed to process Windows theme change', e)
 
@@ -512,6 +528,59 @@ class MainWindow(FluentWindow):
         logger.info('main window tray_quit')
         self.app.quit()
 
+    def set_floating_window_enabled(self, enabled):
+        """Enable/disable the floating overlay panel (\u60ac\u6d6e\u7a97)."""
+        enabled = bool(enabled)
+        logger.info(f'set_floating_window_enabled {enabled}')
+        if enabled:
+            self.show_floating_window()
+        else:
+            self.hide_floating_window()
+        self._sync_floating_window_ui()
+
+    def show_floating_window(self):
+        """Show the floating panel and hide the main window to the tray."""
+        if self.floating_window is None:
+            from ok.ui.qt.widget.FloatingWindow import FloatingWindow
+            self.floating_window = FloatingWindow(self.floating_window_config)
+            self.floating_window.closed.connect(self._on_floating_window_closed)
+        self.floating_window.show()
+        self.floating_window.raise_()
+        self.floating_window_config['enabled'] = True
+        self._sync_floating_window_ui()
+        if self.isVisible() and not self.isMinimized():
+            self.hide()
+        self.tray.showMessage(og.app.title, og.app.tr("Floating Window enabled"))
+        logger.info('floating window shown')
+
+    def hide_floating_window(self):
+        """Hide the floating panel and restore the main window."""
+        if self.floating_window is not None:
+            self.floating_window.hide()
+        self.floating_window_config['enabled'] = False
+        self._sync_floating_window_ui()
+        if self.isMinimized() or not self.isVisible():
+            self.showNormal()
+            self.bring_to_front()
+        logger.info('floating window hidden')
+
+    def _on_floating_window_closed(self):
+        # User closed the floating panel: exit floating mode and restore the
+        # main window.
+        self.hide_floating_window()
+
+    def _sync_floating_window_ui(self):
+        """Keep the tray action and the settings switch in sync."""
+        enabled = bool(self.floating_window_config.get('enabled', False))
+        if hasattr(self, 'floating_tray_action'):
+            self.floating_tray_action.setChecked(enabled)
+        if self.floating_switch_card is not None:
+            self.floating_switch_card.switchButton.blockSignals(True)
+            try:
+                self.floating_switch_card.setChecked(enabled)
+            finally:
+                self.floating_switch_card.switchButton.blockSignals(False)
+
     def show_update_copyright(self):
         title = self.tr('Info')
         content = self.tr(
@@ -559,18 +628,46 @@ class MainWindow(FluentWindow):
                     logger.info('skip copyright dialog because startup version change is shown on about tab')
             # Check for .okscript file in command line arguments
             self._check_okscript_args()
+            self._sync_floating_window_ui()
         super().showEvent(event)
         if first_show:
             QTimer.singleShot(0, self.bring_to_front)
             QTimer.singleShot(250, self.show_startup_version_change_notice)
             self._schedule_update_check()
+            if self.floating_window_config.get('enabled', False):
+                QTimer.singleShot(500, self.show_floating_window)
+
+    def _clamp_geometry_to_screen(self, x, y, width, height):
+        """Keep the restored window on a visible screen.
+
+        The saved position may point to a monitor that is no longer connected
+        (e.g. the user unplugged a second display).  Qt would otherwise place
+        the window off-screen where it cannot be dragged back.
+        """
+        from PySide6.QtWidgets import QApplication
+        right = x + width
+        bottom = y + height
+        for screen in QApplication.screens():
+            area = screen.availableGeometry()
+            if (right > area.left() and x < area.right()
+                    and bottom > area.top() and y < area.bottom()):
+                return x, y
+        primary = QScreen.availableGeometry(QApplication.primaryScreen())
+        x = min(max(x, primary.left()), max(primary.left(), primary.right() - width))
+        y = min(max(y, primary.top()), max(primary.top(), primary.bottom() - height))
+        return x, y
 
     def set_window_size(self, width, height, min_width, min_height):
         screen = QScreen.availableGeometry(self.screen())
         if (self.ok_config['window_width'] > 0 and self.ok_config['window_height'] > 0 and
-                self.ok_config['window_y'] > 0 and self.ok_config['window_x'] > 0):
-            x, y, width, height = (self.ok_config['window_x'], self.ok_config['window_y'],
-                                   self.ok_config['window_width'], self.ok_config['window_height'])
+                self.ok_config['window_y'] >= 0 and self.ok_config['window_x'] >= 0):
+            x = int(self.ok_config['window_x'])
+            y = int(self.ok_config['window_y'])
+            # Restored size must still satisfy the minimum window size, and the
+            # restored position must stay on a currently connected screen.
+            width = max(min_width, int(self.ok_config['window_width']))
+            height = max(min_height, int(self.ok_config['window_height']))
+            x, y = self._clamp_geometry_to_screen(x, y, width, height)
             if self.ok_config['window_maximized']:
                 self.setWindowState(Qt.WindowMaximized)
             else:
@@ -632,10 +729,11 @@ class MainWindow(FluentWindow):
         else:
             self.ok_config['window_maximized'] = False
             geometry = self.geometry()
-            self.ok_config['window_x'] = geometry.x()
-            self.ok_config['window_y'] = geometry.y()
-            self.ok_config['window_width'] = geometry.width()
-            self.ok_config['window_height'] = geometry.height()
+            if geometry.width() > 0 and geometry.height() > 0:
+                self.ok_config['window_x'] = geometry.x()
+                self.ok_config['window_y'] = geometry.y()
+                self.ok_config['window_width'] = geometry.width()
+                self.ok_config['window_height'] = geometry.height()
         logger.info(f'Window geometry updated in ok_config {self.ok_config}')
 
     def starting_emulator(self, done, error, seconds_left):

--- a/ok/ui/qt/settings/SettingTab.py
+++ b/ok/ui/qt/settings/SettingTab.py
@@ -1,7 +1,7 @@
 # coding:utf-8
 from qfluentwidgets import FluentIcon as FIF
 from qfluentwidgets import InfoBar, setTheme
-from qfluentwidgets import (SettingCardGroup, ComboBoxSettingCard, OptionsSettingCard)
+from qfluentwidgets import (SettingCardGroup, ComboBoxSettingCard, OptionsSettingCard, SwitchSettingCard)
 
 from ok import og
 from ok.ui.qt.common.config import cfg
@@ -38,6 +38,13 @@ class SettingTab(Tab):
             ],
             parent=self.basic_group
         )
+
+        self.floating_window_card = SwitchSettingCard(
+            FIF.SEND,
+            og.app.tr('Floating Window'),
+            og.app.tr('Show a compact always-on-top panel above the game window'),
+            parent=self.basic_group
+        )
         self.config_groups = []
         self.__initWidget()
 
@@ -49,6 +56,7 @@ class SettingTab(Tab):
     def __initLayout(self):
         self.basic_group.addSettingCard(self.themeCard)
         self.basic_group.addSettingCard(self.languageCard)
+        self.basic_group.addSettingCard(self.floating_window_card)
 
     def goto_config(self, key):
         to_scroll = None
@@ -74,6 +82,10 @@ class SettingTab(Tab):
                 self.basic_group.addSettingCard(card)
                 self.config_groups.append(card)
 
+    def __onFloatingWindowChanged(self, checked):
+        if og.main_window is not None:
+            og.main_window.set_floating_window_enabled(checked)
+
     def __showRestartTooltip(self):
         """ show restart tooltip """
         InfoBar.success(
@@ -88,3 +100,5 @@ class SettingTab(Tab):
         cfg.appRestartSig.connect(self.__showRestartTooltip)
 
         self.themeCard.optionChanged.connect(lambda ci: setTheme(cfg.get(ci)))
+
+        self.floating_window_card.checkedChanged.connect(self.__onFloatingWindowChanged)

--- a/ok/ui/qt/widget/FloatingWindow.py
+++ b/ok/ui/qt/widget/FloatingWindow.py
@@ -1,0 +1,512 @@
+# coding:utf-8
+"""Compact always-on-top floating panel (悬浮窗) matching the app's fluent UI.
+
+The panel floats above the game window so its buttons can be clicked without
+switching away from the game. It reuses the app's own widgets (Card, TaskCard,
+StatusBar) so the look matches the main window exactly. It is a frameless,
+always-on-top, rectangular panel that can be resized from the bottom-right
+corner. Every task card and button inside is clickable; a live progress card
+shows the current task, elapsed time and task info while it runs.
+"""
+
+import ctypes
+import time
+
+from PySide6.QtCore import QSize, Qt, QTimer, Signal
+from PySide6.QtGui import QColor, QGuiApplication, QPainter, QPen
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+from qfluentwidgets import (
+    BodyLabel,
+    CaptionLabel,
+    FluentIcon,
+    IndeterminateProgressRing,
+    PrimaryPushButton,
+    PushButton,
+    StrongBodyLabel,
+    ToolButton,
+    qconfig,
+)
+
+from ok import Logger, og
+from ok.ui.qt.Communicate import communicate
+from ok.ui.qt.common.design_system import configure_page_layout
+from ok.ui.qt.tasks.TaskCard import TaskCard
+from ok.ui.qt.widget.Card import Card
+from ok.ui.qt.widget.ExpandCardLayout import ExpandCardLayout
+from ok.ui.qt.widget.StatusBar import StatusBar
+
+logger = Logger.get_logger(__name__)
+
+WINDOW_WIDTH = 440
+WINDOW_HEIGHT = 580
+MIN_WIDTH = 300
+MIN_HEIGHT = 360
+
+class _DragBar(QWidget):
+    """Fluent title bar used to drag the floating window."""
+
+    def __init__(self, floating):
+        super().__init__(floating)
+        self._floating = floating
+        self._drag_offset = None
+        self.setFixedHeight(36)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(6, 0, 4, 0)
+        layout.setSpacing(8)
+
+        self.icon_label = QLabel(self)
+        self.icon_label.setFixedSize(20, 20)
+        if og.app is not None and getattr(og.app, 'icon', None) is not None:
+            self.icon_label.setPixmap(og.app.icon.pixmap(20, 20))
+        layout.addWidget(self.icon_label)
+
+        self.title_label = StrongBodyLabel(floating._window_title(), self)
+        layout.addWidget(self.title_label)
+        layout.addStretch(1)
+
+        self.close_button = ToolButton(FluentIcon.CLOSE, self)
+        self.close_button.setFixedSize(30, 30)
+        self.close_button.setToolTip(floating._tr("Close"))
+        self.close_button.clicked.connect(floating._on_close)
+        layout.addWidget(self.close_button)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_offset = (event.globalPosition().toPoint()
+                                 - self.window().frameGeometry().topLeft())
+            event.accept()
+
+    def mouseMoveEvent(self, event):
+        if self._drag_offset is not None and event.buttons() & Qt.MouseButton.LeftButton:
+            self.window().move(event.globalPosition().toPoint() - self._drag_offset)
+            event.accept()
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._drag_offset = None
+            self.window()._save_position()
+            event.accept()
+
+
+class _ResizeGrip(QWidget):
+    """Bottom-right drag handle that resizes the floating panel."""
+
+    SIZE = 18
+
+    def __init__(self, floating):
+        super().__init__(floating)
+        self._floating = floating
+        self._start_global = None
+        self._start_size = None
+        self.setFixedSize(self.SIZE, self.SIZE)
+        self.setCursor(Qt.CursorShape.SizeFDiagCursor)
+        self.setToolTip(floating._tr("Resize"))
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._start_global = event.globalPosition().toPoint()
+            self._start_size = (self._floating.width(), self._floating.height())
+            event.accept()
+
+    def mouseMoveEvent(self, event):
+        if self._start_global is not None and event.buttons() & Qt.MouseButton.LeftButton:
+            delta = event.globalPosition().toPoint() - self._start_global
+            width = max(MIN_WIDTH, self._start_size[0] + delta.x())
+            height = max(MIN_HEIGHT, self._start_size[1] + delta.y())
+            self._floating.resize(width, height)
+            event.accept()
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            self._start_global = None
+            self._start_size = None
+            self._floating._save_position()
+            event.accept()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        pen = QPen(QColor(150, 150, 150), 1)
+        painter.setPen(pen)
+        x = self.width() - 7
+        y = self.height() - 7
+        for i in range(3):
+            painter.drawLine(x, y, x + 4, y + 4)
+            x -= 4
+            y -= 4
+
+
+class FloatingWindow(QWidget):
+    """Frameless always-on-top fluent panel that can be clicked over the game."""
+
+    closed = Signal()
+
+    def __init__(self, config, parent=None):
+        flags = (Qt.WindowType.Tool
+                 | Qt.WindowType.FramelessWindowHint
+                 | Qt.WindowType.WindowStaysOnTopHint)
+        super().__init__(parent, flags)
+        self._config = config
+        self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.setWindowTitle(self._window_title())
+        self.setMinimumSize(MIN_WIDTH, MIN_HEIGHT)
+        self._task_cards = []
+        self._build_ui()
+        self._load_geometry()
+        self._update_theme()
+        qconfig.themeChanged.connect(self._update_theme)
+        communicate.executor_paused.connect(self._update_status)
+        communicate.task.connect(self._update_status)
+        communicate.window.connect(self._update_status)
+        communicate.task_list_updated.connect(self._rebuild_task_lists)
+        self._update_status()
+        self._rebuild_task_lists()
+        self.progress_timer = QTimer(self)
+        self.progress_timer.setInterval(1000)
+        self.progress_timer.timeout.connect(self._refresh_progress)
+        self.progress_timer.start()
+        logger.info('floating window created')
+
+    def _tr(self, key):
+        """Translate with the app gettext catalog, falling back to the key."""
+        if og.app is not None and hasattr(og.app, 'tr'):
+            try:
+                return og.app.tr(key)
+            except Exception:
+                pass
+        return key
+
+    def _window_title(self):
+        """Return the floating window title using the configured app name."""
+        app_name = "OK-WW"
+        if og.app is not None and getattr(og.app, 'title', None):
+            app_name = og.app.title
+        return app_name + " " + self._tr("Floating Window")
+
+    # ---------- UI ----------
+
+    def _build_ui(self):
+        self.container = QFrame(self)
+        self.container.setObjectName("floatingContainer")
+        self.container.setGeometry(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
+        # transparent panel: let the game show through, keep the cards readable
+        self.container.setStyleSheet(
+            "QFrame#floatingContainer { background: transparent; border: none; }")
+
+        root = QVBoxLayout(self.container)
+        root.setContentsMargins(10, 8, 10, 10)
+        root.setSpacing(10)
+
+        # drag bar
+        self.drag_bar = _DragBar(self)
+        root.addWidget(self.drag_bar)
+
+        # live current-task progress card
+        progress_widget = QWidget()
+        progress_layout = QVBoxLayout(progress_widget)
+        progress_layout.setContentsMargins(0, 0, 0, 0)
+        progress_layout.setSpacing(2)
+
+        progress_header = QHBoxLayout()
+        progress_header.setSpacing(8)
+        self.progress_ring = IndeterminateProgressRing()
+        self.progress_ring.setFixedSize(26, 26)
+        self.progress_ring.setStrokeWidth(3)
+        progress_header.addWidget(self.progress_ring, 0, Qt.AlignmentFlag.AlignVCenter)
+        self.progress_name_label = BodyLabel(self._tr("Idle"))
+        progress_header.addWidget(self.progress_name_label, 0, Qt.AlignmentFlag.AlignVCenter)
+        self.progress_time_label = CaptionLabel("")
+        progress_header.addWidget(self.progress_time_label, 0, Qt.AlignmentFlag.AlignVCenter)
+        progress_header.addStretch(1)
+        progress_layout.addLayout(progress_header)
+
+        self.progress_detail_label = CaptionLabel("")
+        self.progress_detail_label.setWordWrap(True)
+        self.progress_detail_label.setMaximumHeight(72)
+        progress_layout.addWidget(self.progress_detail_label)
+
+        self.progress_card = Card("", progress_widget)
+        root.addWidget(self.progress_card)
+
+        # status / start / stop card (same look as the main window StartCard)
+        status_widget = QWidget()
+        status_layout = QHBoxLayout(status_widget)
+        status_layout.setContentsMargins(0, 0, 0, 0)
+        status_layout.setSpacing(8)
+        self.status_bar = StatusBar(self._tr("Idle"), parent=status_widget)
+        status_layout.addWidget(self.status_bar, 0, Qt.AlignmentFlag.AlignVCenter)
+        status_layout.addStretch(1)
+        self.start_button = PrimaryPushButton(FluentIcon.PLAY, self._tr("Start"))
+        self.start_button.clicked.connect(self._toggle_start)
+        status_layout.addWidget(self.start_button, 0, Qt.AlignmentFlag.AlignVCenter)
+        self.stop_button = PushButton(FluentIcon.POWER_BUTTON, self._tr("Stop"))
+        self.stop_button.clicked.connect(self._stop_current_task)
+        status_layout.addWidget(self.stop_button, 0, Qt.AlignmentFlag.AlignVCenter)
+        self.status_card = Card("", status_widget)
+        root.addWidget(self.status_card)
+
+        # scrollable task list
+        self.scroll = QScrollArea(self.container)
+        self.scroll.setWidgetResizable(True)
+        self.scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.scroll.setFrameShape(QFrame.Shape.NoFrame)
+        # keep the scroll area see-through so only the cards are visible
+        self.scroll.setStyleSheet("QScrollArea, QScrollArea > QWidget > QWidget { background: transparent; }")
+        self.scroll.viewport().setAutoFillBackground(False)
+        self.scroll_view = QWidget()
+        self.scroll_view.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground, True)
+        self.scroll_layout = QVBoxLayout(self.scroll_view)
+        configure_page_layout(self.scroll_layout)
+        self.scroll_layout.setContentsMargins(0, 0, 6, 0)
+        self.scroll.setWidget(self.scroll_view)
+        root.addWidget(self.scroll, 1)
+
+        self.tasks_header = StrongBodyLabel(self._tr("Tasks"), self.scroll_view)
+        self.scroll_layout.addWidget(self.tasks_header)
+        self.tasks_view = QWidget(self.scroll_view)
+        self.tasks_layout = ExpandCardLayout(self.tasks_view)
+        self.scroll_layout.addWidget(self.tasks_view)
+
+        self.triggers_header = StrongBodyLabel(self._tr("Triggers"), self.scroll_view)
+        self.scroll_layout.addWidget(self.triggers_header)
+        self.triggers_view = QWidget(self.scroll_view)
+        self.triggers_layout = ExpandCardLayout(self.triggers_view)
+        self.scroll_layout.addWidget(self.triggers_view)
+        self.scroll_layout.addStretch(1)
+
+        # footer
+        footer = QHBoxLayout()
+        self.main_button = PushButton(FluentIcon.HOME, self._tr("Main Window"))
+        self.main_button.clicked.connect(self._open_main_window)
+        footer.addStretch(1)
+        footer.addWidget(self.main_button)
+        root.addLayout(footer)
+
+        # resize handle (bottom-right)
+        self.resize_grip = _ResizeGrip(self)
+        self.resize_grip.move(self.width() - _ResizeGrip.SIZE,
+                              self.height() - _ResizeGrip.SIZE)
+
+    def _update_theme(self, *_args):
+        # keep the panel background transparent regardless of the active theme
+        self.container.setStyleSheet(
+            "QFrame#floatingContainer { background: transparent; border: none; }")
+
+    def _rebuild_task_lists(self, *_args):
+        if not self.isVisible():
+            return
+        for card in self._task_cards:
+            self.tasks_layout.removeWidget(card)
+            self.triggers_layout.removeWidget(card)
+            card.deleteLater()
+        self._task_cards = []
+        if og.executor is None:
+            return
+        try:
+            for task in og.executor.onetime_tasks:
+                if not getattr(task, 'visible', True):
+                    continue
+                card = TaskCard(task, True)
+                self._task_cards.append(card)
+                self.tasks_layout.addWidget(card)
+            for task in og.executor.trigger_tasks:
+                if not getattr(task, 'visible', True):
+                    continue
+                card = TaskCard(task, False)
+                self._task_cards.append(card)
+                self.triggers_layout.addWidget(card)
+            self.tasks_header.setVisible(bool(og.executor.onetime_tasks))
+            self.triggers_header.setVisible(bool(og.executor.trigger_tasks))
+        except Exception as e:
+            logger.error(f'floating window rebuild task lists error: {e}')
+
+    # ---------- native window behavior ----------
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        # Guard against resize events that can arrive while __init__ is still
+        # building the UI (before the container/grip widgets exist).
+        container = getattr(self, 'container', None)
+        if container is not None:
+            container.setGeometry(0, 0, self.width(), self.height())
+        grip = getattr(self, 'resize_grip', None)
+        if grip is not None:
+            grip.move(self.width() - _ResizeGrip.SIZE,
+                      self.height() - _ResizeGrip.SIZE)
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        # The panel may have been hidden while the executor state changed;
+        # refresh the status and task list now that it is visible again.
+        self._update_status()
+        self._rebuild_task_lists()
+
+    # ---------- position ----------
+
+    def _load_geometry(self):
+        width = self._config.get('width', WINDOW_WIDTH)
+        height = self._config.get('height', WINDOW_HEIGHT)
+        if isinstance(width, (int, float)) and isinstance(height, (int, float)):
+            self.resize(max(MIN_WIDTH, int(width)), max(MIN_HEIGHT, int(height)))
+        else:
+            self.resize(WINDOW_WIDTH, WINDOW_HEIGHT)
+        x = self._config.get('x', -1)
+        y = self._config.get('y', -1)
+        if isinstance(x, (int, float)) and isinstance(y, (int, float)) and x >= 0 and y >= 0:
+            self.move(int(x), int(y))
+            return
+        screen = self.screen() or QGuiApplication.primaryScreen()
+        if screen is not None:
+            geo = screen.availableGeometry()
+            self.move(geo.right() - self.width() - 24, geo.top() + 24)
+
+    def _save_position(self):
+        self._config['x'] = int(self.x())
+        self._config['y'] = int(self.y())
+        self._config['width'] = self.width()
+        self._config['height'] = self.height()
+
+    def _clamp_to_screen(self):
+        screen = self.screen() or QGuiApplication.primaryScreen()
+        if screen is None:
+            return
+        geo = screen.availableGeometry()
+        x = max(geo.left(), min(self.x(), geo.right() - self.width()))
+        y = max(geo.top(), min(self.y(), geo.bottom() - self.height()))
+        self.move(int(x), int(y))
+
+    # ---------- progress ----------
+
+    @staticmethod
+    def _time_elapsed(start_time):
+        if not start_time:
+            return ""
+        seconds = max(0, int(time.time() - start_time))
+        hours, rem = divmod(seconds, 3600)
+        minutes, secs = divmod(rem, 60)
+        if hours:
+            return f"{hours}h {minutes}m"
+        return f"{minutes}m {secs:02d}s"
+
+    @staticmethod
+    def _format_task_info(task):
+        info = getattr(task, "info", None)
+        if not isinstance(info, dict) or not info:
+            return ""
+        skip = {"Log", "Error", "Warning", "Liberation Key", "Echo Key", "Chars",
+                "Resonance Key", "Tool Key"}
+        parts = []
+        for key, value in info.items():
+            if key in skip:
+                continue
+            text = str(value)
+            if len(text) > 48:
+                text = text[:48] + "..."
+            parts.append(f"{str(key)}: {text}")
+        return "\n".join(parts[-4:])
+
+    def _refresh_progress(self):
+        if og.executor is None or not self.isVisible():
+            return
+        try:
+            task = og.executor.current_task
+            if task is not None and getattr(task, "running", False):
+                self.progress_ring.start()
+                self.progress_name_label.setText(og.app.tr(task.name) if og.app else task.name)
+                self.progress_time_label.setText(self._time_elapsed(task.start_time))
+                self.progress_detail_label.setText(self._format_task_info(task))
+            elif og.executor.paused:
+                self.progress_ring.stop()
+                self.progress_name_label.setText(self._tr("Paused"))
+                self.progress_time_label.setText("")
+                self.progress_detail_label.setText("")
+            elif task is not None:
+                self.progress_ring.stop()
+                self.progress_name_label.setText(og.app.tr(task.name) if og.app else task.name)
+                self.progress_time_label.setText("")
+                self.progress_detail_label.setText("")
+            else:
+                self.progress_ring.stop()
+                self.progress_name_label.setText(self._tr("Idle"))
+                self.progress_time_label.setText("")
+                self.progress_detail_label.setText("")
+        except Exception as e:
+            logger.debug(f'floating progress refresh failed: {e}')
+
+    # ---------- actions ----------
+
+    def _on_close(self):
+        self.hide()
+        self.closed.emit()
+
+    def _toggle_start(self):
+        if og.executor is None:
+            return
+        if not og.executor.paused:
+            og.executor.pause()
+        else:
+            og.app.start_controller.start()
+
+    def _stop_current_task(self):
+        if og.executor is not None:
+            og.executor.stop_current_task()
+            if not og.executor.paused:
+                og.executor.pause()
+
+    def _open_main_window(self):
+        if og.main_window is not None:
+            og.main_window.bring_to_front()
+
+    # ---------- status ----------
+
+    def _update_status(self, *_args):
+        if og.executor is None:
+            return
+        if not self.isVisible():
+            # Hidden panels (e.g. after closing/collapsing) should not do GUI
+            # work on every window/task signal from the executor thread.
+            return
+        try:
+            if og.executor.paused:
+                self.start_button.setText(self._tr("Start"))
+                self.start_button.setIcon(FluentIcon.PLAY)
+                self.status_bar.setTitle(self._tr("Paused"))
+                self.status_bar.setState(True)
+                self._refresh_progress()
+                return
+            self.start_button.setText(self._tr("Pause"))
+            self.start_button.setIcon(FluentIcon.PAUSE)
+            if not og.executor.connected():
+                self.status_bar.setTitle(self._tr("Game Window Disconnected"))
+                self.status_bar.setState(True)
+            elif og.executor.active_trigger_task_count():
+                if not og.executor.can_capture():
+                    self.status_bar.setTitle(self._tr('Paused: Game Window Must Be in Front'))
+                    self.status_bar.setState(True)
+                else:
+                    count = og.executor.active_trigger_task_count()
+                    self.status_bar.setTitle(
+                        self._tr("Running") + ": " + str(count) + " " + self._tr("Trigger Tasks"))
+                    self.status_bar.setState(False)
+            elif task := og.executor.current_task:
+                if not og.executor.can_capture():
+                    self.status_bar.setTitle(self._tr('Paused: Game Window Must Be in Front'))
+                    self.status_bar.setState(True)
+                elif task.enabled:
+                    self.status_bar.setTitle(self._tr("Running") + ": " + task.name)
+                    self.status_bar.setState(False)
+                else:
+                    self.status_bar.setTitle(self._tr("Waiting for task to be enabled"))
+                    self.status_bar.setState(False)
+            else:
+                self.status_bar.setTitle(self._tr("Waiting for task to be enabled"))
+                self.status_bar.setState(False)
+            self._refresh_progress()
+        except Exception as e:
+            logger.debug(f'floating window update status failed: {e}')

--- a/ok/ui/qt/widget/StatusBar.py
+++ b/ok/ui/qt/widget/StatusBar.py
@@ -51,12 +51,8 @@ class StatusBar(QWidget):
         self.__setQss()
         self.__initLayout()
 
-        self.rotateTimer.start()
+        self._sync_rotate_timer()
 
-    def mousePressEvent(self, event):
-        if event.button() == Qt.LeftButton:
-            # Emit the 'clicked' signal
-            self.clicked.emit()
 
     def __initLayout(self):
         """ initialize layout """
@@ -86,8 +82,36 @@ class StatusBar(QWidget):
         """ set the state of tooltip """
         self.isDone = isDone
         self.update()
+        self._sync_rotate_timer()
         # if isDone:
         #     QTimer.singleShot(1000, self.__fadeOut)
+
+    def _sync_rotate_timer(self):
+        """Only spin the icon while running and visible.
+
+        The rotate timer previously ran forever at 20 Hz even for idle/hidden
+        status bars (main window + every floating window), needlessly waking
+        the GUI thread.
+        """
+        if not self.isDone and self.isVisible():
+            if not self.rotateTimer.isActive():
+                self.rotateTimer.start()
+        else:
+            self.rotateTimer.stop()
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._sync_rotate_timer()
+
+    def hideEvent(self, event):
+        super().hideEvent(event)
+        self.rotateTimer.stop()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            # Emit the 'clicked' signal
+            self.clicked.emit()
+            event.accept()
 
     def __fadeOut(self):
         """ fade out """

--- a/ok/util/process.py
+++ b/ok/util/process.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import re
 import subprocess
+import sys
 import threading
 import time
 from ctypes import wintypes
@@ -61,25 +62,42 @@ def check_mutex():
         logger.error(
             f'Another instance of this application is already running {mutex_name}. Waiting for it to disappear.')
         print(f"Another instance of this application is already running. {mutex_name}")
-        wait_time = 10
+        # Drop our own handle first: while this process keeps a handle to the
+        # named mutex, the kernel object stays alive and the name never
+        # "disappears", so the retry loop below could never succeed.
+        ctypes.windll.kernel32.CloseHandle(mutex)
+        wait_time = 5
         start_time = time.time()
         while time.time() - start_time < wait_time:
             # Try to create the mutex again to check if the other instance has released it
             temp_mutex = _CreateMutex(0, False, mutex_name)
             if _GetLastError() != _ERROR_ALREADY_EXISTS:
-                # Mutex is gone, the other instance likely terminated
+                # Mutex is gone, the other instance likely terminated.  Keep
+                # this handle so the current instance holds the mutex.
                 logger.info(f"Mutex {mutex_name} disappeared. Proceeding.")
-                ctypes.windll.kernel32.CloseHandle(temp_mutex)  # Close the temporary mutex
                 return True  # Proceed with the current instance
             ctypes.windll.kernel32.CloseHandle(temp_mutex)  # Close the temporary mutex
             time.sleep(0.5)  # Wait a bit before retrying
-        # If mutex still exists after waiting, kill the other instance
+        # If mutex still exists after waiting, kill the previous instance.  The
+        # mutex is held by our own packaged interpreter, so pass the current
+        # interpreter path: passing the working directory (as the old code did)
+        # never matched any process exe and the stuck instance survived,
+        # leaving the app unable to start ("Python does not run").
         logger.warning(
-            f"Mutex {mutex_name} still exists after {wait_time} seconds. Attempting to kill existing process.")
-        kill_exe(os.path.abspath(os.getcwd()))
-        # After attempting to kill, the mutex should eventually be released.
-        # You might want to add another short wait here or just let the mutex check
-        # in the next iteration of the main script loop handle it if it restarts.
+            f"Mutex {mutex_name} still exists after {wait_time} seconds. Attempting to kill the previous instance.")
+        kill_exe(abs_path=sys.executable)
+        # Give the killed process a moment to release the mutex.
+        start_time = time.time()
+        while time.time() - start_time < 3:
+            temp_mutex = _CreateMutex(0, False, mutex_name)
+            if _GetLastError() != _ERROR_ALREADY_EXISTS:
+                logger.info(f"Mutex {mutex_name} released after killing the previous instance. Proceeding.")
+                return True
+            ctypes.windll.kernel32.CloseHandle(temp_mutex)
+            time.sleep(0.5)
+        logger.error(
+            f"Mutex {mutex_name} is still held after killing the previous instance; "
+            f"the stuck process may be unkillable (e.g. elevated).")
         return False  # Indicate that a mutex conflict was handled
     return True  # No mutex conflict, proceed
 


### PR DESCRIPTION
### 问题
- 战斗/自动运行时，窗口频繁"无响应/卡死"（Windows 记录为 AppHangB1）。
- 根因：`ok/ui/overlay/win32_gdi.py` 的 `on_draw_box` 每次收到 `draw_box` 事件
  （战斗时每秒成百上千次）都会调用 `_schedule_expiry`，而 `_schedule_expiry` 用
  `threading.Timer` 为每次事件**新建一个线程**。线程风暴（实测进程线程数 1541）导致
  GUI 线程卡死在 `Thread.start()` 等待新线程启动，整个窗口无响应。
- 次要问题：卡死后的旧实例因互斥锁逻辑缺陷无法被杀掉，导致重启后"运行不了"。

### 修复明细
1. **ok/ui/overlay/win32_gdi.py**
   - 移除 `_schedule_expiry` 中每次事件新建 `threading.Timer` 的实现。
   - 改为单个常驻后台线程 `Win32GdiOverlayExpiry` + 小根堆（`heapq`）调度：
     `_schedule_expiry` 只做堆插入 + 条件变量通知，到期回调统一由该线程执行。
   - `close()` 时通过条件变量通知调度线程退出，避免线程泄漏。
   - 实测：战斗场景线程数 1541 -> 57，GUI 持续响应，卡死消失。

2. **ok/util/process.py（check_mutex）**
   - 原实现 `kill_exe(os.path.abspath(os.getcwd()))` 传入的是工作目录，而 `kill_exe`
     按进程 exe 路径匹配，永远匹配不上，卡死旧实例杀不掉。
   - 改为 `kill_exe(abs_path=sys.executable)`，按当前解释器路径真正杀掉旧实例。
   - 等待时间 10s -> 5s；首次 `CreateMutex` 返回 `ERROR_ALREADY_EXISTS` 时先
     `CloseHandle` 释放本进程句柄——否则命名互斥锁因本进程持有句柄而永不释放，
     重试永远失败。杀掉后最多再等 3s 确认互斥锁释放并重新取得所有权。

3. **ok/__init__.py（App.exec）**
   - 新增 GUI 看门狗守护线程 `GuiWatchdog`：
     - 界面 8 秒无响应：调用 `dump_threads()` 把每个线程的 Python 栈写入
       `logs/thread_dumps.txt`（用于诊断卡死现场）。
     - 连续无响应超 120 秒：再次 dump 后 `os._exit(1)` 退出，释放单实例互斥锁，
       保证用户能重新启动。
   - 心跳复用原有 1 秒 `QTimer`，不新增定时器。

4. **ok/capture/windows/dump.py**
   - 原 `dump_threads` 用 `os.getcwd()` 拼日志路径；进程卡死时工作目录可能失效，
     导致 `OSError 22` 写不出文件。
   - 改为基于模块 `__file__` 计算应用目录（`ok/capture/windows/` 上溯三级），依次尝试：
     调用方指定路径 -> `logs/thread_dumps.txt` -> 用户文档目录兜底。
   - pythonw 无 stdout 时不再直接 `print` 崩溃，改为写 stderr 兜底。

5. **ok/ui/qt/widget/StatusBar.py**
   - 旋转图标 `QTimer`（50ms）原先创建后永远运行，空闲或窗口隐藏时也以 20Hz
     持续唤醒 GUI 线程。
   - 改为：仅当 `isDone=False`（运行中）且 `isVisible()` 时启动；
     `setState` / `showEvent` / `hideEvent` 时同步启停。

6. **ok/ui/qt/MainWindow.py**
   - `set_window_size`：恢复历史几何时，若保存位置落在当前任意屏幕之外
     （例如拔掉外接显示器），自动钳制回主屏内，避免窗口跑到屏幕外找不到；
     修复保存位置为 (0,0) 时被忽略的问题；恢复尺寸强制满足最小尺寸。
   - `nativeEvent`：原来每个原生消息都构造完整 `MSG` 并做字符串扫描；改为先只读
     消息 ID，仅对 `WM_DWMCOLORIZATIONCOLORCHANGED` / `WM_SETTINGCHANGE` 做进一步解析。

### 新增功能：可点击悬浮窗（ok/ui/qt/widget/FloatingWindow.py）
- 方形、无折叠、无边框、置顶；右下角可拖拽缩放，位置与尺寸自动记忆。
- 每个任务一行，整行可点：一次性任务 = 开始/停止/继续；触发器任务 = 启用/停用开关。
- 顶部实时进度卡：当前任务名、已运行时长、操作流程详情（每秒刷新，含旋转指示器）。
- 标题栏含"返回主窗口"与关闭按钮；关闭后恢复主窗口。
- 设置页（SettingTab）新增"悬浮窗"开关，系统托盘菜单也可开关。
- 主窗口（MainWindow）新增对应配置与托盘联动。

### 验证
- 带游戏战斗场景连续运行：线程数 1541 -> 57，无 AppHang、无卡死。
- 互斥锁端到端：第二个实例 5 秒内杀掉卡死旧实例并正常接管。
- 悬浮窗收起/缩放/位置记忆、任务点击（Start/开关）经 Qt 事件模拟验证通过。
